### PR TITLE
Generate iCal file from events

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 title: Berlin Tech Workers Coalition
-email: hello@techworkersco.org
+email: contact@techworkerberlin.com
 description: A coalition of tech industry workers, labor organizers, community organizers, and friends cultivating solidarity among all workers in tech.
 url: "https://techworkersberlin.com" # the subpath of your site, e.g. /blog
 baseurl: "" # the base hostname & protocol for your site, e.g. http://example.com

--- a/calendar.data.html
+++ b/calendar.data.html
@@ -1,6 +1,4 @@
 ---
-layout:
-title:
 permalink: /calendar-data/
 ---
 

--- a/events.ics
+++ b/events.ics
@@ -1,0 +1,37 @@
+---
+layout: null
+---
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:https://techworkersberlin.com/
+METHOD:PUBLISH
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+X-LIC-LOCATION:Europe/Berlin
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE{% for post in site.events %}
+BEGIN:VEVENT
+UID:{{ post.date | date: "%Y%m%d" }}@bephpug.de
+ORGANIZER;CN="Berlin TWC":MAILTO:contact@techworkersberlin.com
+LOCATION:Berlin
+SUMMARY:{{ post.title | remove: ',' | remove: ';' }}
+DESCRIPTION:Meetings start at {{ post.date | date: "%H:%M" }} Berlin time. More info at {{ site.url }}{{ post.url }}
+CLASS:PUBLIC
+DTSTART:{{ post.date | date: "%Y%m%d" }}T170000Z
+DTEND:{{ post.date | date: "%Y%m%d" }}T190000Z
+DTSTAMP:{{ post.date | date: "%Y%m%d" }}T170000Z
+END:VEVENT{% endfor %}
+END:VCALENDAR


### PR DESCRIPTION
Addresses #25 
Inspired by this Hugo implementation https://gist.github.com/lislis/2f9b8c51a64cc31c38f9bb83c1da9a35
https://github.com/berlinphp/berlinphp.github.com/blob/master/calendar.ics

You can validate the link https://techworkersberlin.com/events.ics here
https://icalendar.org/validator.html#results


Thank you @lislis and @woodworker!