### PR TITLE
Accidentally used html reserved keyword "referrer"

### DIFF
--- a/_includes/links.html
+++ b/_includes/links.html
@@ -26,8 +26,11 @@
       </div>
 
       <div>
-        <label for="referrer">{% t connect.how_did_hear %}</label>
-        <input class="input-text" id="referrer" type="text" name="referrer">
+        <input class="input-text" id="referrer" type="hidden" name="referrer">
+      </div>
+      <div>
+        <label for="how_did_hear">{% t connect.how_did_hear %}</label>
+        <input class="input-text" id="how_did_hear" type="text" name="how_did_hear">
       </div>
 
       <div class="flex flex-row ai-ctr">


### PR DESCRIPTION
referrer always returns the current url of the page, which is useful, but ignores user input of why/how they heard about us. This attempts to preserve both