### PR TITLE
Improve lighthouse score

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@
 # in the templates via {{ site.myvariable }}.
 title: Berlin Tech Workers Coalition
 email: contact@techworkerberlin.com
-description: Berlin Tech Workers Coalition is a grassroots organization that empowers tech workers to build collective power and get involved in campaigns that make a positive impact on our society.
+description: The tech industry is "disruptive", — including but not limited to gentrification, wage gaps, environmental pollution and militarism. But it does not have to be that way. The Berlin Tech Workers Coalition is a grassroots organization that empowers tech workers to build collective power and get involved in campaigns that make a positive impact on our society.
 url: "https://techworkersberlin.com" # the subpath of your site, e.g. /blog
 baseurl: "" # the base hostname & protocol for your site, e.g. http://example.com
 timezone: "Europe/Berlin"
@@ -35,15 +35,16 @@ plugins:
 image: "/assets/css/images/logo.png"
 twitter:
   username: techworkersber
+  card: summary
 facebook:
-  app_id: 105285494190738
+  publisher: 105285494190738
 
 social:
   name: Berlin Tech Workers Coalition
   links:
     - https://twitter.com/TechWorkersBER
-    - https://www.facebook.com/TechWorkersBER
-
+    - https://facebook.com/TechWorkersBER
+    - https://instagram.com/TechWorkersBER
 
 sass:
   style: compressed

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -30,9 +30,9 @@
             class="aside event-card__date"
             datetime="{{ post.date }}"
           >{{ post.date | localize: site.lang }}</time>
-          <h3 class="event-card__title ">
+          {% if limit %}<h3{% else %}<h2{% endif %} class="event-card__title ">
             <a href="{{ post.url }}" class="event-card__link">{{ post.title }}</a>
-          </h3>
+          {% if limit %}</h3>{% else %}</h2>{% endif %}
         </div>
       </article>
     </li>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
   <div class="columns">
     {% for link in site.footer_links %}
         {% if link.newTab %}
-          <div class="column is-1"><a target="_blank" href="{{ link.url }}">{{ link.text }}</a></div>
+          <div class="column is-1"><a rel="noopener" target="_blank" href="{{ link.url }}">{{ link.text }}</a></div>
         {% else %}
           <div class="column is-1"><a href="{{ link.url }}">{{ link.text }}</a></div>
         {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,6 @@
     {% endcapture %}
     {{ styles | scssify }}
   </style>
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
   <link rel="shortcut icon" href="/assets/css/images/logo.png" type="image/x-icon">
   <link rel="icon" href="/assets/css/images/logo.png" type="image/x-icon">

--- a/_includes/main.scss
+++ b/_includes/main.scss
@@ -150,8 +150,11 @@ img {
   color: $white;
   padding: 5px 20px 20px;
 
-  a:hover {
+  a {
     color: $white;
+    &:hover {
+      text-decoration-color: #e6141b;
+    }
   }
 }
 

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -30,12 +30,12 @@
                 datetime="{{ post.date | date: '%Y-%m-%d' }}"
               >{{ post.date | date: '%-d %B %Y' }}</time>
             </section>
-            <h3
+            {% if limit %}<h3{% else %}<h2{% endif %}
               class="event-card__title"
               id="news-{{ post.title | slugify }}"
             >
               <a href="{{ post.url }}" class="event-card__link">{{ post.title }}</a>
-            </h3>
+            {% if limit %}</h3>{% else %}</h2>{% endif %}
         </article>
       </li>
   {% endfor %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -27,7 +27,7 @@ permalink: /
 
 
 <section class="titled-block" aria-labelledby="hl-links">
-  <h2 id="hl-link">{% t connect.title %}</h2>
+  <h2 id="hl-links">{% t connect.title %}</h2>
   {% include links.html %}
 </section>
 

--- a/press_mentions.md
+++ b/press_mentions.md
@@ -35,9 +35,9 @@ permalink_de: /pressespiegel
             {{post.media}} —
             <time datetime="{{ post.date | date: '%Y-%m-%d' }}">{{ post.date | date: '%-d %B %Y' }}</time>
           </div>
-          <h3 class="event-card__title ">
+          <h2 class="event-card__title ">
             <a hreflang="{{post.lang}}-DE" href="{{ post.url }}" class="event-card__link">{{ post.title }}</a>
-          </h3>
+          </h2>
         </div>
       </article>
     </li>


### PR DESCRIPTION
Improves best practices and number of lighthouse errors. Except for SEO category which cannot be easily tested in test environment, the scores for all other categories are now perfect 100's! Tested on home page and `/events` pages. 

For example this events page, had a canonical_url set to another page, because it was largely duplicated content. On production, it shows two different canonical_urls (root domain and external link) while with this PR it only shows the external link and is therefore valid. 
- https://sitechecker.pro/canonical-url/ 
- see: https://techworkersberlin.com/events/25 
- versus https://deploy-preview-107--techworkersberlin.netlify.app/events/25

Before:
<img width="452" alt="Screenshot 2020-10-05 at 02 22 22" src="https://user-images.githubusercontent.com/7111514/95030854-c260c800-06b2-11eb-9b84-a1d7ef6a07b0.png">
After:
<img width="441" alt="Screenshot 2020-10-05 at 02 22 28" src="https://user-images.githubusercontent.com/7111514/95030856-c391f500-06b2-11eb-8bc6-766fcffe468f.png">
