### PR TITLE
Add edit this page on translated pages at top, and always in the footer.

### DIFF
--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -13,7 +13,7 @@ home:
       summary: TWC Berlin unterstützt die Kampagne <a href="https://zero-covid.org">ZeroCovid</a>. Arbeitgeber müssen Verantwortung für die Sicherheit und Gesundheit ihrer Mitarbeiter*innen übernehmen und wo immer möglich Home Office ermöglichen. In nicht systemrelevanten Bereichen der Industrie, wo dies nicht möglich ist, braucht es dringend einen solidarischen Shutdown, um die Pandemie zu bekämpfen. Falls Dein Arbeitgeber keine adequaten Schutzmaßnahmen trifft, oder Home Office verweigert, kontaktiere uns für mögliche Unterstützung (auch anonym) unter zero-covid@techworkersberlin.com
 
   dw_enteignen:
-    summary: Wir als Berlin Tech Workers Coalition unterstützen die Kampagne <a href="https://www.dwenteignen.de/">Deutsche Wohnen & Co enteignen</a>. Für alle wahlberechtigten Berliner*innen gibt es Infos zum Unterschreiben <a href="https://www.dwenteignen.de/unterschreiben/">hier</a>.  
+    summary: Wir als Berlin Tech Workers Coalition unterstützen die Kampagne <a href="https://www.dwenteignen.de/">Deutsche Wohnen & Co enteignen</a>. Für alle wahlberechtigten Berliner*innen gibt es Infos zum Unterschreiben <a href="https://www.dwenteignen.de/unterschreiben/">hier</a>.
 
   events:
     title: Events
@@ -36,6 +36,7 @@ connect:
   subscribe: Registrieren
 
 global:
+  edit_this_page: Diese Seite bearbeiten
   code_of_conduct:
     title: Code of Conduct
     summary: Sämtliche Kommunikation, persönliche und virtuelle Treffen erfolgen unter dem <a rel="noopener noreferrer" target="_blank" href="https://berlincodeofconduct.org/de">Berlin Code of Conduct</a>. Die Privatsphäre und Sicherheit unserer Teilnehmer*innen sind uns wichtig. Es ist strengstens untersagt, die Identiät von Personen zu teilen sowie Fotos, Videos oder sonstige Aufzeichungen anzufertigen, sofern dem nicht explizit zugestimmt wurde.

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -14,9 +14,9 @@ home:
   zero_covid:
     title: ZERO COVID
     summary:  We as TWC Berlin support the <a href="https://zero-covid.org/language/en/">ZeroCovid</a> campaign. Employers must take responsibility for the health and safety of workers and support working from home wherever possible. In all branches of industry where this is not possible and that are non-essential, a solidarity shutdown is urgently needed to fight the pandemic. If your employer fails to protect your health by adequate measures, or denies home office and you would like to discuss how we can support you, please contact us (also anonymously) on zero-covid@techworkersberlin.com
-  
+
   dw_enteignen:
-    summary: We as Berlin TWC support the <a href="https://www.dwenteignen.de/wp-content/uploads/2021/03/a5_DWE_INFOFLYER_ENGLISCH.pdf">Deutsche Wohnen & Co enteignen</a> campaign. If you live in Berlin and are eligible to vote, find out how to sign <a href="https://www.dwenteignen.de/unterschreiben/">here</a>.  
+    summary: We as Berlin TWC support the <a href="https://www.dwenteignen.de/wp-content/uploads/2021/03/a5_DWE_INFOFLYER_ENGLISCH.pdf">Deutsche Wohnen & Co enteignen</a> campaign. If you live in Berlin and are eligible to vote, find out how to sign <a href="https://www.dwenteignen.de/unterschreiben/">here</a>.
 
   events:
     title: Latest Events
@@ -39,6 +39,7 @@ connect:
   subscribe: Subscribe
 
 global:
+  edit_this_page: Edit This Page
   code_of_conduct:
     title: Code of Conduct
     summary: All meetings and communications are covered under the <a rel="noopener noreferrer" target="_blank" href="https://berlincodeofconduct.org">Berlin Code of Conduct</a>. The privacy and safety of our members is important to us. Sharing the identity of members and or taking/sharing photos are strictly forbidden unless express consent is given.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,11 +1,12 @@
 <footer class="site-footer">
   <div class="columns">
     {% for link in site.footer_links %}
-        {% if link.newTab %}
-          <div class="column is-1"><a rel="noopener" target="_blank" href="{{ link.url }}">{{ link.text }}</a></div>
-        {% else %}
-          <div class="column is-1"><a href="{{ link.url }}">{{ link.text }}</a></div>
-        {% endif %}
+      {% if link.newTab %}
+        <div class="column is-1"><a rel="noopener" target="_blank" href="{{ link.url }}">{{ link.text }}</a></div>
+      {% else %}
+        <div class="column is-1"><a href="{{ link.url }}">{{ link.text }}</a></div>
+      {% endif %}
     {% endfor %}
+    <div class="column is-1"><a rel="noopener" target="_blank" href="https://github.com/techworkersco/twc-site-berlin/edit/develop/{{ page.path }}">{% t global.edit_this_page %}</a></div>
   </div>
 </footer>

--- a/_layouts/translated.html
+++ b/_layouts/translated.html
@@ -3,6 +3,9 @@ layout: default
 ---
 {% if page.namespace %}
   <div align="right">
+    <a href="https://github.com/techworkersco/twc-site-berlin/edit/develop/{{ page.path }}" target="_blank">
+      <b>{% t global.edit_this_page %}</b>
+    </a> 🌍
     {% assign languages = page.languages | default: site.languages %}
     {% for lang in languages %}
       {% if languages.size == 1 %}


### PR DESCRIPTION
Currently, if a user sees a mistake, that do not have a way to contribute or correct it, beyond email/reaching out over social media/Twitter. We could link to a template/pull request format, that informs people how to make a PR etc.. and actively encourage content/translation improvements along with more technical ones