### PR TITLE
Optionally hide signup form when there is one to minimize confusion

### DIFF
--- a/_events/16.md
+++ b/_events/16.md
@@ -2,7 +2,7 @@
 title:  "Intro to forming a Works Council"
 date:   2020-01-11 14:00:00 +0100
 tags:
- - training
+ - works-council
 ---
 
 ## A beginner friendly introduction to forming a Works Council (Betriebsrat) in your workplace

--- a/_events/organizing-for-power-6-weekly-sessions.md
+++ b/_events/organizing-for-power-6-weekly-sessions.md
@@ -2,6 +2,7 @@
 title: Organizing For Power (6 weekly sessions)
 date: 2021-05-18T16:00:00.000Z
 image: https://files.jotform.com/jufs/jeffrousset/form_files/Zoom%20and%20email-O4Pdesign.604fe417a36017.86319049.png
+hide_form: true  
 ---
 **Organizing for Power (O4P)** is an online training and networking program for organizers worldwide. More than 10,000 workers from 6 continents and 70 countries have joined O4P trainings in the past 18 months.
 
@@ -9,7 +10,7 @@ image: https://files.jotform.com/jufs/jeffrousset/form_files/Zoom%20and%20email-
 
 This training features new trainers and inspiring campaign stories from around the world. Using mixed methodologies and small-group sessions, participants will focus on developing core organizing skills including: leader identification, 1-on-1 conversations, charting, and structure tests.
 
-### FAQ: 
+### FAQ:
 
 **What**: Organizing 4 Power Training. 12 hour training in total (6 sessions, 2 hours each)**Who:** Over 1,000 organizers will be attending. Tech Workers Coalition will have about 30+ tech workers attending both Track A and Track B from multiple cities.
 

--- a/_events/works-council-training-for-beginners-1.md
+++ b/_events/works-council-training-for-beginners-1.md
@@ -3,7 +3,18 @@ title: Works Council Training for Beginners
 date: 2021-02-24T18:30:00.000Z
 tags:
   - works-council
+hide_form: true
 ---
 ## 24 February 2021 19:30 CET
 
 Registration for this session is [mandatory](https://us02web.zoom.us/meeting/register/tZMrdOCorzMpHtERVAqux7eukx1TsXuQOHxy) to ensure a safe environment for everyone. These will be held bi-weekly.
+
+## Accessibility
+
+The event will be held over Zoom, a video conferencing platform. You can use Zoom with your desktop, laptop, or mobile device.
+
+You need an internet connection and speakers to listen, and a microphone (and optionally camera) to participate. You can also join the conversation via the (written) chat.
+
+There will be a brief presentation with static slides, but most of the event will be audio-based discussion in English.
+
+If you would like to know more, check out Zoom’s documentation on their accessibility features or reach out to us at accessibility@techworkersberlin.com

--- a/_events/works-council-training-for-beginners-2.md
+++ b/_events/works-council-training-for-beginners-2.md
@@ -2,11 +2,12 @@
 title: Works Council Training for Beginners
 date: 2021-10-14T17:30:22.263Z
 tags:
-  - training
+  - works-council
+hide_form: true
 ---
 ## 14 October 2021 19:30 CET
 
-Registration for this session is [mandatory](https://us02web.zoom.us/meeting/register/tZYrdeChrj0vHNb3turmmPd1drZqnXhCjX6b) to ensure a safe environment for everyone. These trainings are held bi-monthly. 
+Registration for this session is [mandatory](https://us02web.zoom.us/meeting/register/tZYrdeChrj0vHNb3turmmPd1drZqnXhCjX6b) to ensure a safe environment for everyone. These trainings are held bi-monthly.
 
 ## Accessibility
 

--- a/_events/works-council-training-for-beginners-3.md
+++ b/_events/works-council-training-for-beginners-3.md
@@ -2,11 +2,12 @@
 title: Works Council Training for Beginners
 date: 2021-12-07T18:30:08.593Z
 tags:
-  - training
+  - works-council
+hide_form: true  
 ---
 ## 7 December 2021 19:30 CET
 
-Registration for this session is [mandatory](https://us02web.zoom.us/meeting/register/tZwpc--vrD4tE9WYzpHXHxn9Lj9HVLkEIFY_) to ensure a safe environment for everyone. These trainings are held bi-monthly. 
+Registration for this session is [mandatory](https://us02web.zoom.us/meeting/register/tZwpc--vrD4tE9WYzpHXHxn9Lj9HVLkEIFY_) to ensure a safe environment for everyone. These trainings are held bi-monthly.
 
 ## Accessibility
 

--- a/_events/works-council-training-for-beginners-5.md
+++ b/_events/works-council-training-for-beginners-5.md
@@ -3,6 +3,7 @@ title: Works Council Training for Beginners
 date: 2022-04-21T17:30:00.000Z
 tags:
   - works-council
+hide_form: true  
 ---
 ## 21 April 2022 19:30 CET
 

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -32,79 +32,81 @@
     Telegram</a
   >
 </div>
-<div class="social-links">
-  <form name="subscribe" class="join-form" method="POST" data-netlify="true">
-    <div>
-      <label for="email">{% t connect.email %}</label>
-      <input
-        class="input-text"
-        id="email"
-        type="email"
-        required
-        name="email"
-      />
-    </div>
-    <div>
-      <label for="name">{% t connect.name %}</label>
-      <input class="input-text" id="name" type="text" required name="name" />
-    </div>
-    <div>
-      <label for="social1">{% t connect.public_link %} #1</label>
-      <input
-        class="input-text"
-        id="social1"
-        required
-        type="text"
-        name="social_media_1"
-      />
-    </div>
-    <div>
-      <label for="social2">{% t connect.public_link %} #2</label>
-      <input
-        class="input-text"
-        id="social2"
-        required
-        type="text"
-        name="social_media_2"
-      />
-    </div>
-    <div>
-      <label for="company">{% t connect.company %}</label>
-      <input class="input-text" id="company" type="text" name="company" />
-    </div>
+{% unless page.hide_form %}
+  <div class="social-links">
+    <form name="subscribe" class="join-form" method="POST" data-netlify="true">
+      <div>
+        <label for="email">{% t connect.email %}</label>
+        <input
+          class="input-text"
+          id="email"
+          type="email"
+          required
+          name="email"
+        />
+      </div>
+      <div>
+        <label for="name">{% t connect.name %}</label>
+        <input class="input-text" id="name" type="text" required name="name" />
+      </div>
+      <div>
+        <label for="social1">{% t connect.public_link %} #1</label>
+        <input
+          class="input-text"
+          id="social1"
+          required
+          type="text"
+          name="social_media_1"
+        />
+      </div>
+      <div>
+        <label for="social2">{% t connect.public_link %} #2</label>
+        <input
+          class="input-text"
+          id="social2"
+          required
+          type="text"
+          name="social_media_2"
+        />
+      </div>
+      <div>
+        <label for="company">{% t connect.company %}</label>
+        <input class="input-text" id="company" type="text" name="company" />
+      </div>
 
-    <div>
-      <input class="input-text" id="referrer" type="hidden" name="referrer" />
-    </div>
-    <div>
-      <label for="how_did_hear">{% t connect.how_did_hear %}</label>
-      <input
-        class="input-text"
-        id="how_did_hear"
-        type="text"
-        name="how_did_hear"
-      />
-    </div>
+      <div>
+        <input class="input-text" id="referrer" type="hidden" name="referrer" />
+      </div>
+      <div>
+        <label for="how_did_hear">{% t connect.how_did_hear %}</label>
+        <input
+          class="input-text"
+          id="how_did_hear"
+          type="text"
+          name="how_did_hear"
+        />
+      </div>
 
-    <div class="flex flex-row ai-ctr">
-      <label for="subscribeSlack"
-        ><b>{% t connect.subscribe_to_slack %}</b></label
-      >
-      <input id="subscribeSlack" type="checkbox" name="slack" checked />
-    </div>
-    <div>
-      <label for="subscribeNewsletter"
-        ><b>{% t connect.subscribe_to_newsletter %}</b></label
-      >
-      <input
-        id="subscribeNewsletter"
-        type="checkbox"
-        name="newsletter"
-        checked
-      />
-    </div>
-    <button class="subscribe-button" type="submit">
-      {% t connect.subscribe %}
-    </button>
-  </form>
-</div>
+      <div class="flex flex-row ai-ctr">
+        <label for="subscribeSlack"
+          ><b>{% t connect.subscribe_to_slack %}</b></label
+        >
+        <input id="subscribeSlack" type="checkbox" name="slack" checked />
+      </div>
+      <div>
+        <label for="subscribeNewsletter"
+          ><b>{% t connect.subscribe_to_newsletter %}</b></label
+        >
+        <input
+          id="subscribeNewsletter"
+          type="checkbox"
+          name="newsletter"
+          checked
+        />
+      </div>
+      <button class="subscribe-button" type="submit">
+        {% t connect.subscribe %}
+      </button>
+    </form>
+  </div>
+{% endunless %}  

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -12,7 +12,9 @@ layout: default
 
     <h2>{% translate global.code_of_conduct.title %}</h2>
     {% translate global.code_of_conduct.summary %}
-    <h2>{% translate connect.info %}</h2>
-    {% include links.html %}
+    {% unless page.hide_form %}
+      <h2>{% translate connect.info %}</h2>
+      {% include links.html %}
+    {% endunless %}
   </div>
 </article>

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -12,9 +12,7 @@ layout: default
 
     <h2>{% translate global.code_of_conduct.title %}</h2>
     {% translate global.code_of_conduct.summary %}
-    {% unless page.hide_form %}
       <h2>{% translate connect.info %}</h2>
       {% include links.html %}
-    {% endunless %}
   </div>
 </article>

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -15,8 +15,8 @@ collections:
     fields: # The fields for each document, usually in front matter
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Date", name: "date", widget: "datetime"}
-      - {label: "Alternate Url", name: "canonical_url", widget: "string", required: false}
+      - {label: "hide signup form", name: "hide_form", widget: "boolean", default: false}
+      - {label: "Canonical url", name: "canonical_url", widget: "string", required: false}
       - {label: "Tags", name: "tags", widget: "list"}
       - {label: "Body", name: "body", widget: "markdown"}
-      - {label: "optional image for SEO", name: "image", widget: "image", required: false}
-      - {label: "hide default signup form?", name: "hide_form", widget: "boolean", default: false}
+      - {label: "Optional image for SEO", name: "image", widget: "image", required: false}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -19,3 +19,4 @@ collections:
       - {label: "Tags", name: "tags", widget: "list"}
       - {label: "Body", name: "body", widget: "markdown"}
       - {label: "optional image for SEO", name: "image", widget: "image", required: false}
+      - {label: "hide default signup form?", name: "hide_form", widget: "boolean", default: false}


### PR DESCRIPTION
Also updated tags of some past works-council related events. They're not actively used, but could be used to auto generate/load inside https://techworkersberlin.com/works-councils the same way we autoload articles with same tags