### PR TITLE
Improve various feeds

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -19,7 +19,7 @@ home:
     summary: We as Berlin TWC support the <a href="https://www.dwenteignen.de/wp-content/uploads/2021/03/a5_DWE_INFOFLYER_ENGLISCH.pdf">Deutsche Wohnen & Co enteignen</a> campaign. If you live in Berlin and are eligible to vote, find out how to sign <a href="https://www.dwenteignen.de/unterschreiben/">here</a>.
 
   events:
-    title: Latest Events
+    title: 5 Recent events
     summary: Find [all upcoming events here](/events)
 
   news:

--- a/_i18n/pl.yml
+++ b/_i18n/pl.yml
@@ -9,7 +9,7 @@ home:
 
   events:
     title: Nadchodzące wydarzenia
-    summary: Zerknij, co planujemy w najbliższym czasie—albo przejrzyj całe [archiwum wydarzeń](/events).
+    summary: Zerknij, co planujemy w najbliższym czasie—albo przejrzyj całe [archiwum wydarzeń](/pl/events).
 
 connect:
   info: informacje kontaktowe

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -6,6 +6,7 @@ layout: default
 <!-- Output author details if some exist. -->
 <article class="post">
   <header class="post-header">
+    <a href="/events">Read more articles</a>
     <h1 class="post-title">{{ page.title | escape }}</h1>
     {% assign author = site.data.authors[page.author] | default: site.data.authors['techworkersber'] %}
       <section class="l-stack -horizontal -space-large">

--- a/news.md
+++ b/news.md
@@ -2,5 +2,5 @@
 layout: page
 permalink: /news
 ---
-<h1>Article Archive</h1>
+<h1>Articles</h1>
 {% include news.html %}

--- a/themes.md
+++ b/themes.md
@@ -1,10 +1,10 @@
 ---
 languages: ["en", "de"]
 layout: translated
-namespace: menu
-permalink: /menu
+namespace: directory
+permalink: /directory
 ---
-# Themes Directory
+# Directory
 <ul
   class="list -no-list-style l-stack -vertical"
   style="--stack-spacing: 1.5rem"
@@ -80,6 +80,30 @@ permalink: /menu
         style="--stack-spacing: 0.25rem">
         <h2 class="event-card__title ">
           <a href="/social-issues" class="event-card__link">Social issues</a>
+        </h2>
+      </div>
+    </article>
+  </li>
+  <li>
+    <article class="event-card">
+      <svg
+        focusable="false"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        x="0px"
+        y="0px"
+        viewBox="0 0 24 24"
+        class="event-card__icon"
+        style="enable-background:new 0 0 24 24;"
+        xml:space="preserve">
+        <path d="M20,3h-1V1h-2v2H7V1H5v2H4C2.9,3,2,3.9,2,5v16c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V5C22,3.9,21.1,3,20,3z M20,21H4V8h16V21z"/>
+        <text transform="matrix(1 0 0 1 5.3281 19.1641)" class="st0 st1">{{ site.events.size }}</text>
+      </svg>
+      <div
+        class="event-card__info-column l-stack -vertical"
+        style="--stack-spacing: 0.25rem">
+        <h2 class="event-card__title ">
+          <a href="/events" class="event-card__link">Events</a>
         </h2>
       </div>
     </article>

--- a/themes.md
+++ b/themes.md
@@ -34,7 +34,7 @@ permalink: /menu
         class="event-card__info-column l-stack -vertical"
         style="--stack-spacing: 0.25rem">
         <h2 class="event-card__title ">
-          <a href="/news" class="event-card__link">Blog posts</a>
+          <a href="/news" class="event-card__link">Articles</a>
         </h2>
       </div>
     </article>

--- a/works-councils/works-councils.md
+++ b/works-councils/works-councils.md
@@ -5,7 +5,7 @@ tags: works-councils
 ---
 # Works Councils
 
-As Tech Workers Coalition, we support the formation of Works Councils as a means to organize and gain collective power within your workplace. Below is some basic information on the German system of Works Councils (Betriebsräte). If you'd like to learn more or have plans to initiate a campaign at your workplace, please get in touch or join us in our next general meeting. Please be aware that this it not legal advice.
+As Tech Workers Coalition, we support the formation of Works Councils (Betriebsräte) as a means to organize and gain collective power within your workplace. Below is some basic information on the German system of Works Councils. If you'd like to learn more or have plans to initiate a campaign at your workplace, please get in touch or join us in our next general meeting. Please be aware that this it not legal advice.
 
 [What is a Works Council]({% link works-councils/what-is-a-works-council.md %})
 
@@ -15,10 +15,12 @@ As Tech Workers Coalition, we support the formation of Works Councils as a means
 
 ## Training
 
-We host Works Council training sessions every two weeks, including an introduction to the German Works Council and union system and the possibility to discuss strategic questions and formal considerations of a Works Council campaign. We aim to provide an open forum and safe space to share experiences and learn from each other.
+We host Works Council trainings regularly, including an introduction to the German Works Council and trade union structures and the possibility to discuss strategic questions and formal considerations of a Works Council campaign. We provide an open forum and safe space to share experiences and learn from each other.
 
-Please check the [Events](/events) section for upcoming times and registration form.
+## Event
+Please check the [Events](/events) section for upcoming times and registration form. The three most recent events are:
 
+{% include events.html tags="works-council" limit=3 %}
 
 ## Articles
 


### PR DESCRIPTION
* This improves https://techworkersberlin.com/works-councils by showing 3 latest works-council related events. Compare it with the preview page at https://deploy-preview-194--techworkersberlin.netlify.app/works-councils
* It makes it easier to find all https://techworkersberlin.com/news articles on home page, but also from within each news article, compare it with https://deploy-preview-194--techworkersberlin.netlify.app/news
* The /directory page isn't used/active anywhere, but I added the events to it and renamed it from menu to directory, since it's a directory of info. See it at https://deploy-preview-194--techworkersberlin.netlify.app/directory