### PR TITLE
WIP: Generate a works council candidate/supporters table

### DIFF
--- a/_includes/links.html
+++ b/_includes/links.html
@@ -35,11 +35,11 @@
 {% unless page.hide_form %}
   <div class="social-links">
     <form name="subscribe" class="join-form" method="POST" data-netlify="true">
-      <div>
+      <div class="control">
         <label for="name">{% t connect.name %}</label>
         <input class="input-text" id="name" type="text" required name="name" />
       </div>
-      <div>
+      <div class="control">
         <label for="email">{% t connect.email %}</label>
         <input
           class="input-text"
@@ -49,7 +49,7 @@
           name="email"
         />
       </div>
-      <div>
+      <div class="control">
         <label for="social1">{% t connect.public_link %} #1</label>
         <input
           class="input-text"
@@ -59,7 +59,7 @@
           name="social_media_1"
         />
       </div>
-      <div>
+      <div class="control">
         <label for="social2">{% t connect.public_link %} #2</label>
         <input
           class="input-text"
@@ -69,7 +69,7 @@
           name="social_media_2"
         />
       </div>
-      <div>
+      <div class="control">
         <label for="company">{% t connect.company %}</label>
         <input class="input-text" id="company" type="text" name="company" />
       </div>
@@ -77,7 +77,7 @@
       <div>
         <input class="input-text" id="referrer" type="hidden" name="referrer" />
       </div>
-      <div>
+      <div class="control">
         <label for="how_did_hear">{% t connect.how_did_hear %}</label>
         <input
           class="input-text"

--- a/_includes/main.js
+++ b/_includes/main.js
@@ -38,48 +38,36 @@ function candidateTable() {
   caption.innerHTML = caption_text
 }
 
+const employeeCounts = {
+  5: 0,
+  21: 1,
+  51: 3,
+  101: 5,
+  201: 7,
+  401: 9,
+  701: 11,
+  1001: 13,
+  1501: 15,
+  2001: 17,
+  2501: 19,
+  3001: 21,
+  3501: 23,
+  4001: 25,
+  4501: 27,
+  5001: 29,
+  6001: 31,
+  7001: 33,
+  9001: 35
+}
+
 function worksCouncilSize(employeeCount) {
-  if (employeeCount < 6) {
-    return 0
-  } else if (employeeCount < 21) {
-    return 1
-  } else if (employeeCount < 51) {
-    return 3
-  } else if (employeeCount < 101) {
-    return 5
-  } else if (employeeCount < 201) {
-    return 7
-  } else if (employeeCount < 401) {
-    return 9
-  } else if (employeeCount < 701) {
-    return 11
-  } else if (employeeCount < 1001) {
-    return 13
-  } else if (employeeCount < 1501) {
-    return 15
-  } else if (employeeCount < 2001) {
-    return 17
-  } else if (employeeCount < 2501) {
-    return 19
-  } else if (employeeCount < 3001) {
-    return 21
-  } else if (employeeCount < 3501) {
-    return 23
-  } else if (employeeCount < 4001) {
-    return 25
-  } else if (employeeCount < 4501) {
-    return 27
-  } else if (employeeCount < 5001) {
-    return 29
-  } else if (employeeCount < 6001) {
-    return 31
-  } else if (employeeCount < 7001) {
-    return 33
-  } else if (employeeCount < 9001) {
-    return 35
-  } else {
-    return Math.ceil((employeeCount - 9000)/3000.0) + 35
+ for (const limit in employeeCounts) {
+   if (employeeCount < limit) {
+     return employeeCounts[limit];
+    }
   }
+  // if the lookup table doesn't furnish a provided limit
+  return Math.ceil((employeeCount - 9000)/3000)*2 + 35
 }
 
 function supportingCandidates(employeeCount){ return Math.min(employeeCount/20, 50)}

--- a/_includes/main.js
+++ b/_includes/main.js
@@ -6,19 +6,35 @@ trigger.addEventListener('click', function(e) {
     element.classList.toggle('hide');
 });
 
+let exampleEmployeeCount = Math.floor(Math.random() * (1000 - 25 + 1)) + 25;
+
+function onLoad(){
+  let employee_count = localStorage.getItem('election.employee_count')
+  document.getElementById('employee_count').value = employee_count;
+  document.getElementById('candidate_count').value = localStorage.getItem('election.candidate_count');
+  document.getElementById('list_name').value = localStorage.getItem('election.list_name');
+  document.getElementById('list_owners').value = localStorage.getItem('election.list_owners');
+
+  if (employee_count){
+    handleTemplateGeneratorFormSubmit();
+  }
+}
+
 function handleTemplateGeneratorFormSubmit() {
+  persistForm()
   signaturesTable()
   candidateTable()
-  persistForm()
+}
+
+function handleTemplateGeneratorExampleFormSubmit() {
+  exampleEmployeeCount = Math.floor(Math.random() * (1000 - 25 + 1)) + 25;
+  signaturesTable(true)
+  candidateTable(true)
 }
 
 function persistValue(id) {
-  const el = document.getElementById(id);
-  if(!el || !el.value || el.value.length === 0) {
-    return
-  } else {
-    window.localStorage.setItem("election." + id, el.value)
-  }
+  const value = document.getElementById(id).value;
+  window.localStorage.setItem("election." + id, value || '')
 }
 
 function persistForm() {
@@ -38,28 +54,47 @@ function listName() {
   return (localStorage.getItem('election.list_name') || listOwners()) || ''
 }
 
-function candidateTable() {
+function employeeCount(isExample){
+  return isExample ? exampleEmployeeCount : parseInt(localStorage.getItem('election.employee_count'))
+}
+
+function candidateTable(isExample) {
   const tableBody = document.querySelector("#candidates_id");
   const caption = document.querySelector("#candidate_table > caption");
-  let list_owners = localStorage.getItem('election.list_owners') || ''; // document.getElementById('list_owners').value
+  let list_owners = localStorage.getItem('election.list_owners') || '';
 
-  let caption_text = `${worksCouncil()} coworkers will represent you in your future Works Council.
-    Candidate list proposal: ${listName()} ideally has ${candidates()} candidates.
-    ${supporters()} supporting signature(s) are also necessary, once all the candidates for ${listName()} list are finalized.
+  let caption_text = `${worksCouncil(isExample)} coworkers will represent you and your ${employeeCount(isExample) - 1 } in your future Works Council.
+    Candidate list proposal: ${listName()} ideally has ${candidates(isExample)} candidates.
+    ${supporters(isExample)} supporting signature(s) are also necessary, once all the candidates for ${listName()} list are finalized.
   `
 
   let tableData = ""
-  for (let i = 0; i < candidates(); i++) {
-     tableData +=
-     `<tr>
-        <td>${i == 0 ? candidate1() : ''}</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-     </tr>`
- }
+  if (!isExample) {
+    for (let i = 0; i < candidates(); i++) {
+      tableData +=
+      `<tr>
+      <td>${i == 0 ? candidate1() : ''}</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      </tr>`
+    }
+  } else {
+    for (let i = 0; i < candidates(isExample); i++) {
+      genders = ["male", "female", "diverse", "non-binary"];
+       tableData +=
+      `<tr>
+        <td>${randomItem(firstNames)}</td>
+        <td>${randomItem(lastNames)}</td>
+        <td>${randomDate()}</td>
+        <td>${randomItem(genders)}</td>
+        <td>${randomItem(jobTitles)}</td>
+        <td>${randomItem(["😅", "🙈", "✊", "👾"])}</td>
+       </tr>`
+     }
+  }
 
   tableBody.innerHTML = tableData;
   caption.innerHTML = caption_text
@@ -73,40 +108,90 @@ function candidate1(){
  }
 }
 
-function signaturesTable() {
+function randomItem(items){
+  return items[Math.floor(Math.random()* items.length)]
+}
+
+function getRandomInt(max) {
+  return Math.floor(Math.random() * max);
+}
+
+function randomDate() {
+  let start = new Date('1970-01-01')
+  let end = new Date('2004-12-31')
+
+  return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime())).toLocaleDateString();
+}
+
+function signaturesTable(isExample) {
   const tableSignatureBody = document.querySelector("#signatures_id");
   const tableCandidateSignatureBody = document.querySelector("#signatures_candidate_id");
   const caption = document.querySelector("#signature_candidate_table > caption");
   let caption_text = `
-    List proposal ${listName()} needs at least ${supporters()} supporting signature
-    for the following candidates of the ${listName()} list nomination.`
+    List proposal Solidarity needs at least ${supporters(isExample)} supporting signatures
+    for the following candidates of the Solidarity list nomination.`
 
+  if (!isExample) {
+    caption_text = `List proposal ${listName()} needs at least ${supporters()} supporting signatures
+    for the following candidates of the ${listName()} list nomination.`
+  }
   let candidateData = ""
+
+  if (!isExample) {
+    for (let i = 0; i < candidates(); i++) {
+       candidateData +=
+      `<tr>
+        <td>#${i+1}</td>
+        <td>${ i == 0 ? candidate1() : '' }</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+       </tr>`
+     }
+  } else {
   for (let i = 0; i < candidates(); i++) {
+    genders = ["male", "female", "diverse", "non-binary"];
      candidateData +=
     `<tr>
       <td>#${i+1}</td>
-      <td>${ i == 0 ? candidate1() : '' }</td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
+      <td>${randomItem(firstNames)}</td>
+      <td>${randomItem(lastNames)}</td>
+      <td>${randomDate()}</td>
+      <td>${randomItem(genders)}</td>
+      <td>${randomItem(jobTitles)}</td>
      </tr>`
+   }
   }
 
+
   let tableData = ""
-  for (let i = 0; i < supporters(); i++) {
-    let bgColor = i + 1 < supporters() ? "#FFCCCB" : "#66FF99"
-    let text = "#FFCCCB" == bgColor ? "Almost" : "Congrats!"
-    tableData +=
-    `<tr>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td style="background-color:${bgColor}">${text}</td>
-   </tr>`
+  if (!isExample) {
+    for (let i = 0; i < supporters(); i++) {
+      let bgColor = i + 1 < supporters() ? "#FFCCCB" : "#66FF99"
+      let text = "#FFCCCB" == bgColor ? "Almost" : "Congrats!"
+      tableData +=
+      `<tr>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td style="background-color:${bgColor}">${text}</td>
+     </tr>`
+    }
+    tableData += extraSupporterRows()
+  } else {
+    for (let i = 0; i < supporters(isExample); i++) {
+      let bgColor = i + 1 < supporters(isExample) ? "#FFCCCB" : "#66FF99"
+      let text = "#FFCCCB" == bgColor ? "Almost" : "Congrats!"
+      tableData +=
+      `<tr>
+        <td>${randomItem(firstNames)}</td>
+        <td>${randomItem(lastNames)}</td>
+        <td>${randomItem(["😅", "🙈", "✊", "👾"])}</td>
+        <td style="background-color:${bgColor}">${text}</td>
+     </tr>`
+    }
   }
-  tableData += extraSupporterRows()
 
   tableSignatureBody.innerHTML = tableData;
   tableCandidateSignatureBody.innerHTML = candidateData;
@@ -151,8 +236,12 @@ const employeeThreshholds = {
   9001: 35
 }
 
-function worksCouncil() {
- let employees = parseInt(localStorage.getItem('election.employee_count'))
+const lastNames = ["Schmidt", "Miller", "Xi", "Patel", "Ortez", "Goldman", "Shevchenko", "Melnyk", "Popova"]
+const firstNames = ["Chris", "Sam", "Hannah", "Raj", "Aditi", "Thomas", "Marie", "Mahmoud"];
+const jobTitles = ["Venture capitalist", "Customer support", "Working student", "Warehouse picker", "IT support", "QA engineer", "Delivery rider", "Marketing manager", "Software engineer"]
+
+function worksCouncil(isExample) {
+ let employees = employeeCount(isExample)
  for (const limit in employeeThreshholds) {
    if (employees < limit) {
      return employeeThreshholds[limit];
@@ -162,13 +251,16 @@ function worksCouncil() {
   return Math.ceil((employees - 9000)/3000)*2 + 35
 }
 
-function candidates() {
+function candidates(isExample) {
+  if (isExample) {
+    return 2 * worksCouncil(isExample)
+  }
   // if unknown, double works council size is recommended
   return parseInt(localStorage.getItem('election.candidate_count')) || 2 * worksCouncil()
 }
 
-function supporters() {
-  let employees = parseInt(localStorage.getItem('election.employee_count'))
+function supporters(isExample) {
+  let employees = employeeCount(isExample)
   if (employees < 21) {
     return 0
   } else if (employees < 101 ) {
@@ -176,3 +268,5 @@ function supporters() {
   } else
   return Math.min(Math.ceil(employees * 1.0 / 20), 50)
 }
+
+onLoad();

--- a/_includes/main.js
+++ b/_includes/main.js
@@ -5,3 +5,81 @@ trigger.addEventListener('click', function(e) {
     e.preventDefault();
     element.classList.toggle('hide');
 });
+
+function candidateTable() {
+  const tableBody = document.querySelector("#tableCandidateBody");
+  const caption = document.querySelector("#candidate_table > caption");
+  let employeeCount = parseInt(document.getElementById('employee_count').value);
+  let list_owners = document.getElementById('list_owners').value
+  let list_name = document.getElementById('list_name').value || list_owners
+  let recommended_candidates_size = worksCouncilSize(employee_count)*2;
+
+
+  let caption_text = `
+    The future works council will have ${worksCouncilSize(employee_count)} members.
+    Candidate <b>list proposal: ${list_name}</b> ideally has ${recommended_candidates_size} candidates.
+    A mandatory ${supportingCandidates(worksCouncilSize(employee_count))} supporting signatures are also necessary, once all candidates are collected.
+  `
+
+  tableData = ""
+    for (let i = 0; i < recommended_candidates_size; i++) {
+       tableData +=
+       `<tr>
+          <td>#${i+1}</td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+       </tr>`
+   }
+
+  tableBody.innerHTML = tableData;
+  caption.innerHTML = caption_text
+}
+
+function worksCouncilSize(employeeCount) {
+  if (employeeCount < 6) {
+    return 0
+  } else if (employeeCount < 21) {
+    return 1
+  } else if (employeeCount < 51) {
+    return 3
+  } else if (employeeCount < 101) {
+    return 5
+  } else if (employeeCount < 201) {
+    return 7
+  } else if (employeeCount < 401) {
+    return 9
+  } else if (employeeCount < 701) {
+    return 11
+  } else if (employeeCount < 1001) {
+    return 13
+  } else if (employeeCount < 1501) {
+    return 15
+  } else if (employeeCount < 2001) {
+    return 17
+  } else if (employeeCount < 2501) {
+    return 19
+  } else if (employeeCount < 3001) {
+    return 21
+  } else if (employeeCount < 3501) {
+    return 23
+  } else if (employeeCount < 4001) {
+    return 25
+  } else if (employeeCount < 4501) {
+    return 27
+  } else if (employeeCount < 5001) {
+    return 29
+  } else if (employeeCount < 6001) {
+    return 31
+  } else if (employeeCount < 7001) {
+    return 33
+  } else if (employeeCount < 9001) {
+    return 35
+  } else {
+    return Math.ceil((employeeCount - 9000)/3000.0) + 35
+  }
+}
+
+function supportingCandidates(employeeCount){ return Math.min(employeeCount/20, 50)}

--- a/_includes/main.js
+++ b/_includes/main.js
@@ -10,6 +10,31 @@ function employeeCount(){
   return parseInt(document.getElementById('employee_count').value);
 }
 
+function handleTemplateGeneratorFormSubmit() {
+  signaturesTable()
+  candidateTable()
+  persistForm()
+}
+
+function persistValue(id) {
+  const el = document.getElementById(id);
+  if(!el || !el.value || el.value.length === 0) {
+    return
+  }
+  if(el.attributes.type && el.attributes.type === "number") {
+    window.localStorage.setItem("candidates." + id, parseInt(el.value))
+  }
+  else {
+    window.localStorage.setItem("candidates." + id, el.value)
+  }
+}
+
+function persistForm() {
+  persistValue('employee_count')
+  persistValue('list_owners')
+  persistValue('list_name')
+}
+
 function candidateTable() {
   const tableBody = document.querySelector("#candidates_id");
   const caption = document.querySelector("#candidate_table > caption");

--- a/_includes/main.js
+++ b/_includes/main.js
@@ -24,31 +24,44 @@ function candidateTable() {
   `
 
   tableData = ""
-    for (let i = 0; i < worksCouncilSize(employee_count)*2; i++) {
-       tableData +=
-       `<tr>
-          <td>#${i+1}</td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-       </tr>`
-   }
+  for (let i = 0; i < worksCouncilSize(employee_count)*2; i++) {
+     tableData +=
+     `<tr>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+     </tr>`
+ }
 
   tableBody.innerHTML = tableData;
   caption.innerHTML = caption_text
 }
 
 function signaturesTable() {
-  const tableBody = document.querySelector("#signatures_id");
+  const tableSignatureBody = document.querySelector("#signatures_id");
+  const tableCandidateSignatureBody = document.querySelector("#signatures_candidate_id");
   const caption = document.querySelector("#supporter_signature_table > caption");
 
   let employee_count = employeeCount();
   let caption_text = `
     A mandatory ${supportingCandidates(employee_count)} supporting signatures are also necessary, once all candidates are collected.
   `
+
+  candidateData = ""
+  for (let i = 0; i < worksCouncilSize(employee_count)*2; i++) {
+     candidateData +=
+     `<tr>
+        <td>#${i+1}</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+     </tr>`
+  }
 
   tableData = ""
     for (let i = 0; i < supportingCandidates(employee_count); i++) {
@@ -63,9 +76,8 @@ function signaturesTable() {
        </tr>`
    }
 
-  tableData +=
-
-  tableBody.innerHTML = tableData;
+  tableSignatureBody.innerHTML = tableData;
+  tableCandidateSignatureBody.innerHTML = candidateData;
   caption.innerHTML = caption_text
 }
 

--- a/_includes/main.js
+++ b/_includes/main.js
@@ -63,7 +63,7 @@ function candidateTable(isExample) {
   const caption = document.querySelector("#candidate_table > caption");
   let list_owners = localStorage.getItem('election.list_owners') || '';
 
-  let caption_text = `${worksCouncil(isExample)} coworkers will represent you and your ${employeeCount(isExample) - 1 } in your future Works Council.
+  let caption_text = `${worksCouncil(isExample)} coworkers will represent you and your ${employeeCount(isExample) - 1 } co-workers in your future Works Council.
     Candidate list proposal: ${listName()} ideally has ${candidates(isExample)} candidates.
     ${supporters(isExample)} supporting signature(s) are also necessary, once all the candidates for ${listName()} list are finalized.
   `

--- a/_includes/main.js
+++ b/_includes/main.js
@@ -16,11 +16,7 @@ function persistValue(id) {
   const el = document.getElementById(id);
   if(!el || !el.value || el.value.length === 0) {
     return
-  }
-  if(el.attributes.type && el.attributes.type === "number") {
-    window.localStorage.setItem("candidates." + id, parseInt(el.value))
-  }
-  else {
+  } else {
     window.localStorage.setItem("candidates." + id, el.value)
   }
 }

--- a/_includes/main.js
+++ b/_includes/main.js
@@ -17,32 +17,42 @@ function persistValue(id) {
   if(!el || !el.value || el.value.length === 0) {
     return
   } else {
-    window.localStorage.setItem("candidates." + id, el.value)
+    window.localStorage.setItem("election." + id, el.value)
   }
 }
 
 function persistForm() {
   persistValue('employee_count')
+  persistValue('candidate_count')
   persistValue('list_owners')
   persistValue('list_name')
+}
+
+function listOwners() {
+  // currently no option to directly enter candidate names, but when that happens this can be generated from that
+  return localStorage.getItem('election.list_owners') || ''
+}
+
+function listName() {
+  // if a list name is not provided, the first two names on list suffice
+  return (localStorage.getItem('election.list_name') || listOwners()) || ''
 }
 
 function candidateTable() {
   const tableBody = document.querySelector("#candidates_id");
   const caption = document.querySelector("#candidate_table > caption");
-  let list_owners = localStorage.getItem('candidates.list_owners') || ''; // document.getElementById('list_owners').value
-  let list_name = (localStorage.getItem('candidates.list_owners') || list_owners) || ''
-  let caption_text = `
-    ${worksCouncil()} coworkers will represent you in your future Works Council.
-    Candidate list proposal: ${list_name} ideally has ${worksCouncil()*2} candidates.
-    ${supporters()} supporting signature(s) are also necessary, once all the candidates for ${list_name} list are finalized.
+  let list_owners = localStorage.getItem('election.list_owners') || ''; // document.getElementById('list_owners').value
+
+  let caption_text = `${worksCouncil()} coworkers will represent you in your future Works Council.
+    Candidate list proposal: ${listName()} ideally has ${candidates()} candidates.
+    ${supporters()} supporting signature(s) are also necessary, once all the candidates for ${listName()} list are finalized.
   `
 
-  tableData = ""
-  for (let i = 0; i < worksCouncil()*2; i++) {
+  let tableData = ""
+  for (let i = 0; i < candidates(); i++) {
      tableData +=
      `<tr>
-        <td></td>
+        <td>${i == 0 ? candidate1() : ''}</td>
         <td></td>
         <td></td>
         <td></td>
@@ -55,43 +65,68 @@ function candidateTable() {
   caption.innerHTML = caption_text
 }
 
+function candidate1(){
+  if (listOwners()){
+   return listOwners().split(",")[0]
+ } else {
+   return ''
+ }
+}
+
 function signaturesTable() {
   const tableSignatureBody = document.querySelector("#signatures_id");
   const tableCandidateSignatureBody = document.querySelector("#signatures_candidate_id");
-  const caption = document.querySelector("#supporter_signature_table > caption");
+  const caption = document.querySelector("#signature_candidate_table > caption");
   let caption_text = `
-   ${supporters()} supporting signatures are necessary to support this list.
-  `
+    List proposal ${listName()} needs at least ${supporters()} supporting signature
+    for the following candidates of the ${listName()} list nomination.`
 
-  candidateData = ""
-  for (let i = 0; i < worksCouncil()*2; i++) {
+  let candidateData = ""
+  for (let i = 0; i < candidates(); i++) {
      candidateData +=
-     `<tr>
-        <td>#${i+1}</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
+    `<tr>
+      <td>#${i+1}</td>
+      <td>${ i == 0 ? candidate1() : '' }</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
      </tr>`
   }
 
-  tableData = ""
-    for (let i = 0; i < supporters(); i++) {
-       let bgColor = i + 1 < supporters() ? "#FFCCCB" : "#66FF99"
-       let text = "#FFCCCB" == bgColor ? "Almost" : "Congrats!"
-       tableData +=
-       `<tr>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td style="background-color:${bgColor}">${text}</td>
-       </tr>`
-   }
+  let tableData = ""
+  for (let i = 0; i < supporters(); i++) {
+    let bgColor = i + 1 < supporters() ? "#FFCCCB" : "#66FF99"
+    let text = "#FFCCCB" == bgColor ? "Almost" : "Congrats!"
+    tableData +=
+    `<tr>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td style="background-color:${bgColor}">${text}</td>
+   </tr>`
+  }
+  tableData += extraSupporterRows()
 
   tableSignatureBody.innerHTML = tableData;
   tableCandidateSignatureBody.innerHTML = candidateData;
   caption.innerHTML = caption_text
+}
+
+function extraSupporterRows() {
+  // when no signatures are required, extras are not either
+  if (supporters() < 2) {
+    return ''
+  } else {
+  rowsHTML =
+  `<tr>
+     <td></td>
+     <td></td>
+     <td></td>
+     <td style="background-color:#FFD2669">Optional extra signatures</td>
+  </tr>`.repeat(Math.min(supporters(), 5))
+  return rowsHTML
+  }
 }
 
 const employeeThreshholds = {
@@ -117,7 +152,7 @@ const employeeThreshholds = {
 }
 
 function worksCouncil() {
- let employees = parseInt(localStorage.getItem('candidates.employee_count'))
+ let employees = parseInt(localStorage.getItem('election.employee_count'))
  for (const limit in employeeThreshholds) {
    if (employees < limit) {
      return employeeThreshholds[limit];
@@ -127,12 +162,17 @@ function worksCouncil() {
   return Math.ceil((employees - 9000)/3000)*2 + 35
 }
 
+function candidates() {
+  // if unknown, double works council size is recommended
+  return parseInt(localStorage.getItem('election.candidate_count')) || 2 * worksCouncil()
+}
+
 function supporters() {
-  let employees = parseInt(localStorage.getItem('candidates.employee_count'))
+  let employees = parseInt(localStorage.getItem('election.employee_count'))
   if (employees < 21) {
     return 0
   } else if (employees < 101 ) {
     return 2
   } else
-  return Math.min(Math.ceil(employees/20), 50)
+  return Math.min(Math.ceil(employees * 1.0 / 20), 50)
 }

--- a/_includes/main.js
+++ b/_includes/main.js
@@ -6,23 +6,25 @@ trigger.addEventListener('click', function(e) {
     element.classList.toggle('hide');
 });
 
+function employeeCount(){
+  return parseInt(document.getElementById('employee_count').value);
+}
+
 function candidateTable() {
-  const tableBody = document.querySelector("#tableCandidateBody");
+  const tableBody = document.querySelector("#candidates_id");
   const caption = document.querySelector("#candidate_table > caption");
-  let employeeCount = parseInt(document.getElementById('employee_count').value);
   let list_owners = document.getElementById('list_owners').value
   let list_name = document.getElementById('list_name').value || list_owners
-  let recommended_candidates_size = worksCouncilSize(employee_count)*2;
 
-
+  let count = employeeCount();
   let caption_text = `
-    The future works council will have ${worksCouncilSize(employee_count)} members.
-    Candidate <b>list proposal: ${list_name}</b> ideally has ${recommended_candidates_size} candidates.
-    A mandatory ${supportingCandidates(worksCouncilSize(employee_count))} supporting signatures are also necessary, once all candidates are collected.
+    The future works council will have ${worksCouncilSize(count)} members.
+    Candidate <b>list proposal: ${list_name}</b> ideally has ${worksCouncilSize(employeeCount())*2} candidates.
+    A mandatory ${supportingCandidates(employeeCount())} supporting signatures are also necessary, once all candidates are collected.
   `
 
   tableData = ""
-    for (let i = 0; i < recommended_candidates_size; i++) {
+    for (let i = 0; i < worksCouncilSize(employeeCount())*2; i++) {
        tableData +=
        `<tr>
           <td>#${i+1}</td>
@@ -31,8 +33,37 @@ function candidateTable() {
           <td></td>
           <td></td>
           <td></td>
+          <td></td>
        </tr>`
    }
+
+  tableBody.innerHTML = tableData;
+  caption.innerHTML = caption_text
+}
+
+function signaturesTable() {
+  const tableBody = document.querySelector("#signatures_id");
+  const caption = document.querySelector("#supporter_signature_table > caption");
+
+  let count = employeeCount();
+  let caption_text = `
+    A mandatory ${supportingCandidates(employeeCount())} supporting signatures are also necessary, once all candidates are collected.
+  `
+
+  tableData = ""
+    for (let i = 0; i < supportingCandidates(employeeCount()); i++) {
+       let bgColor = i + 1 < supportingCandidates(employeeCount()) ? "#FFCCCB" : "#66FF99"
+       let text = "#FFCCCB" == bgColor ? "Almost" : "Congrats!"
+       tableData +=
+       `<tr>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td style="background-color:${bgColor}">${text}</td>
+       </tr>`
+   }
+
+  tableData +=
 
   tableBody.innerHTML = tableData;
   caption.innerHTML = caption_text
@@ -60,9 +91,9 @@ const employeeCounts = {
   9001: 35
 }
 
-function worksCouncilSize(employeeCount) {
+function worksCouncilSize(employees) {
  for (const limit in employeeCounts) {
-   if (employeeCount < limit) {
+   if (employees < limit) {
      return employeeCounts[limit];
     }
   }
@@ -70,4 +101,4 @@ function worksCouncilSize(employeeCount) {
   return Math.ceil((employeeCount - 9000)/3000)*2 + 35
 }
 
-function supportingCandidates(employeeCount){ return Math.min(employeeCount/20, 50)}
+function supportingCandidates(employeeCount) { return Math.min(employeeCount/20, 50)}

--- a/_includes/main.js
+++ b/_includes/main.js
@@ -6,10 +6,6 @@ trigger.addEventListener('click', function(e) {
     element.classList.toggle('hide');
 });
 
-function employeeCount(){
-  return parseInt(document.getElementById('employee_count').value);
-}
-
 function handleTemplateGeneratorFormSubmit() {
   signaturesTable()
   candidateTable()
@@ -38,18 +34,16 @@ function persistForm() {
 function candidateTable() {
   const tableBody = document.querySelector("#candidates_id");
   const caption = document.querySelector("#candidate_table > caption");
-  let list_owners = document.getElementById('list_owners').value
-  let list_name = document.getElementById('list_name').value || list_owners
-
-  let employee_count = employeeCount();
+  let list_owners = localStorage.getItem('candidates.list_owners') || ''; // document.getElementById('list_owners').value
+  let list_name = (localStorage.getItem('candidates.list_owners') || list_owners) || ''
   let caption_text = `
-    The future works council will have ${worksCouncilSize(employee_count)} members.
-    Candidate <b>list proposal: ${list_name}</b> ideally has ${worksCouncilSize(employee_count)*2} candidates.
-    A mandatory ${supportingCandidates(employee_count)} supporting signatures are also necessary, once all candidates are collected.
+    ${worksCouncil()} coworkers will represent you in your future Works Council.
+    Candidate list proposal: ${list_name} ideally has ${worksCouncil()*2} candidates.
+    ${supporters()} supporting signature(s) are also necessary, once all the candidates for ${list_name} list are finalized.
   `
 
   tableData = ""
-  for (let i = 0; i < worksCouncilSize(employee_count)*2; i++) {
+  for (let i = 0; i < worksCouncil()*2; i++) {
      tableData +=
      `<tr>
         <td></td>
@@ -69,14 +63,12 @@ function signaturesTable() {
   const tableSignatureBody = document.querySelector("#signatures_id");
   const tableCandidateSignatureBody = document.querySelector("#signatures_candidate_id");
   const caption = document.querySelector("#supporter_signature_table > caption");
-
-  let employee_count = employeeCount();
   let caption_text = `
-    A mandatory ${supportingCandidates(employee_count)} supporting signatures are also necessary, once all candidates are collected.
+   ${supporters()} supporting signatures are necessary to support this list.
   `
 
   candidateData = ""
-  for (let i = 0; i < worksCouncilSize(employee_count)*2; i++) {
+  for (let i = 0; i < worksCouncil()*2; i++) {
      candidateData +=
      `<tr>
         <td>#${i+1}</td>
@@ -89,8 +81,8 @@ function signaturesTable() {
   }
 
   tableData = ""
-    for (let i = 0; i < supportingCandidates(employee_count); i++) {
-       let bgColor = i + 1 < supportingCandidates(employeeCount()) ? "#FFCCCB" : "#66FF99"
+    for (let i = 0; i < supporters(); i++) {
+       let bgColor = i + 1 < supporters() ? "#FFCCCB" : "#66FF99"
        let text = "#FFCCCB" == bgColor ? "Almost" : "Congrats!"
        tableData +=
        `<tr>
@@ -106,7 +98,7 @@ function signaturesTable() {
   caption.innerHTML = caption_text
 }
 
-const employeeCounts = {
+const employeeThreshholds = {
   5: 0,
   21: 1,
   51: 3,
@@ -128,21 +120,23 @@ const employeeCounts = {
   9001: 35
 }
 
-function worksCouncilSize(employees) {
- for (const limit in employeeCounts) {
+function worksCouncil() {
+ let employees = parseInt(localStorage.getItem('candidates.employee_count'))
+ for (const limit in employeeThreshholds) {
    if (employees < limit) {
-     return employeeCounts[limit];
+     return employeeThreshholds[limit];
     }
   }
   // if the lookup table doesn't furnish a provided limit
-  return Math.ceil((employeeCount - 9000)/3000)*2 + 35
+  return Math.ceil((employees - 9000)/3000)*2 + 35
 }
 
-function supportingCandidates(employeeCount) {
-  if (employeeCount < 21) {
+function supporters() {
+  let employees = parseInt(localStorage.getItem('candidates.employee_count'))
+  if (employees < 21) {
     return 0
-  } else if (employeeCount < 101 ) {
+  } else if (employees < 101 ) {
     return 2
   } else
-  return Math.min(Math.ceil(employeeCount/20), 50)
+  return Math.min(Math.ceil(employees/20), 50)
 }

--- a/_includes/main.js
+++ b/_includes/main.js
@@ -16,15 +16,15 @@ function candidateTable() {
   let list_owners = document.getElementById('list_owners').value
   let list_name = document.getElementById('list_name').value || list_owners
 
-  let count = employeeCount();
+  let employee_count = employeeCount();
   let caption_text = `
-    The future works council will have ${worksCouncilSize(count)} members.
-    Candidate <b>list proposal: ${list_name}</b> ideally has ${worksCouncilSize(employeeCount())*2} candidates.
-    A mandatory ${supportingCandidates(employeeCount())} supporting signatures are also necessary, once all candidates are collected.
+    The future works council will have ${worksCouncilSize(employee_count)} members.
+    Candidate <b>list proposal: ${list_name}</b> ideally has ${worksCouncilSize(employee_count)*2} candidates.
+    A mandatory ${supportingCandidates(employee_count)} supporting signatures are also necessary, once all candidates are collected.
   `
 
   tableData = ""
-    for (let i = 0; i < worksCouncilSize(employeeCount())*2; i++) {
+    for (let i = 0; i < worksCouncilSize(employee_count)*2; i++) {
        tableData +=
        `<tr>
           <td>#${i+1}</td>
@@ -45,13 +45,13 @@ function signaturesTable() {
   const tableBody = document.querySelector("#signatures_id");
   const caption = document.querySelector("#supporter_signature_table > caption");
 
-  let count = employeeCount();
+  let employee_count = employeeCount();
   let caption_text = `
-    A mandatory ${supportingCandidates(employeeCount())} supporting signatures are also necessary, once all candidates are collected.
+    A mandatory ${supportingCandidates(employee_count)} supporting signatures are also necessary, once all candidates are collected.
   `
 
   tableData = ""
-    for (let i = 0; i < supportingCandidates(employeeCount()); i++) {
+    for (let i = 0; i < supportingCandidates(employee_count); i++) {
        let bgColor = i + 1 < supportingCandidates(employeeCount()) ? "#FFCCCB" : "#66FF99"
        let text = "#FFCCCB" == bgColor ? "Almost" : "Congrats!"
        tableData +=

--- a/_includes/main.js
+++ b/_includes/main.js
@@ -101,4 +101,11 @@ function worksCouncilSize(employees) {
   return Math.ceil((employeeCount - 9000)/3000)*2 + 35
 }
 
-function supportingCandidates(employeeCount) { return Math.min(employeeCount/20, 50)}
+function supportingCandidates(employeeCount) {
+  if (employeeCount < 21) {
+    return 0
+  } else if (employeeCount < 101 ) {
+    return 2
+  } else
+  return Math.min(Math.ceil(employeeCount/20), 50)
+}

--- a/_includes/main.scss
+++ b/_includes/main.scss
@@ -4,6 +4,7 @@
 @import "elements/a";
 @import "elements/typography";
 @import "structures/lists";
+@import "structures/tables";
 
 @import "structures/main";
 @import "structures/event";

--- a/_includes/main.scss
+++ b/_includes/main.scss
@@ -13,6 +13,8 @@
 
 @import "layouts/home";
 
+@import "layouts/nominating-candidates";
+
 @import "util/helper";
 @import "util/layout";
 

--- a/_includes/main.scss
+++ b/_includes/main.scss
@@ -53,6 +53,28 @@ body {
 input {
   display: inline-block;
   margin: 10px 0;
+
+  &:invalid {
+    border: 2px solid red;
+  }
+
+  &:invalid:required {
+    background: #FFCCCB;
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+}
+
+input.input-text {
+  margin-bottom: 5px;
+  border-radius: 5px;
+  border-color: $grey;
+  border-style: solid;
+  border-width: 1px;
+
 }
 
 input[type="submit"] {
@@ -131,9 +153,18 @@ ul {
   border-radius: 8px;
   padding: 10px;
   margin-bottom: 5px;
-  
+
   a {
     text-decoration: none;
+  }
+}
+
+.control {
+  margin-bottom: 5px;
+
+  input, label {
+    display: block;
+    width: 75%;
   }
 }
 
@@ -173,17 +204,6 @@ img {
   color: $white;
 }
 
-input.input-text {
-  margin-bottom: 5px;
-  border-radius: 5px;
-  border-color: $grey;
-  border-style: solid;
-  border-width: 1px;
-
-  &:focus {
-    outline: none;
-  }
-}
 
 .subscribe-button {
   border-color: transparent;

--- a/_sass/layouts/_nominating-candidates.scss
+++ b/_sass/layouts/_nominating-candidates.scss
@@ -1,0 +1,8 @@
+@media print {
+    main {
+        max-width: 100%
+    }
+    .header, .site-footer, p, .social-links, caption {
+        display: none;
+    }
+}

--- a/_sass/structures/_tables.scss
+++ b/_sass/structures/_tables.scss
@@ -1,0 +1,22 @@
+table {
+  font-family: Arial, Helvetica, sans-serif;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+table td, table th {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+
+table tr:nth-child(even){background-color: #f2f2f2;}
+
+table tr:hover {background-color: #ddd;}
+
+table th {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  text-align: left;
+  background-color: #04AA6D;
+  color: white;
+}

--- a/_sass/structures/_tables.scss
+++ b/_sass/structures/_tables.scss
@@ -8,9 +8,14 @@ table td, table th, caption {
   padding: 8px;
 }
 
-table tr:nth-child(even){background-color: #f2f2f2;}
+table tr {
+  height: 32px;
 
-table tr:hover {background-color: #ddd;}
+  &:hover {background-color: #ddd;}
+  &:nth-child(even){background-color: #f2f2f2;}
+}
+
+
 
 table th, caption {
   padding-top: 12px;
@@ -25,4 +30,5 @@ table th {
 
 caption {
   background-color: red;
+  font-weight: bolder;
 }

--- a/_sass/structures/_tables.scss
+++ b/_sass/structures/_tables.scss
@@ -18,7 +18,8 @@ table tr {
 .page-break {
   break-after: page;
 }
-
+// show table header on every page in printer mode across browsers
+thead { display: table-header-group; }
 
 table th, caption {
   padding-top: 12px;

--- a/_sass/structures/_tables.scss
+++ b/_sass/structures/_tables.scss
@@ -15,6 +15,9 @@ table tr {
   &:nth-child(even){background-color: #f2f2f2;}
 }
 
+.page-break {
+  break-after: page;
+}
 
 
 table th, caption {

--- a/_sass/structures/_tables.scss
+++ b/_sass/structures/_tables.scss
@@ -1,10 +1,9 @@
 table {
-  font-family: Arial, Helvetica, sans-serif;
   border-collapse: collapse;
   width: 100%;
 }
 
-table td, table th {
+table td, table th, caption {
   border: 1px solid #ddd;
   padding: 8px;
 }
@@ -13,10 +12,17 @@ table tr:nth-child(even){background-color: #f2f2f2;}
 
 table tr:hover {background-color: #ddd;}
 
-table th {
+table th, caption {
   padding-top: 12px;
   padding-bottom: 12px;
   text-align: left;
-  background-color: #04AA6D;
   color: white;
+}
+
+table th {
+  background-color: #04AA6D;
+}
+
+caption {
+  background-color: red;
 }

--- a/works-councils/list-nomination.md
+++ b/works-councils/list-nomination.md
@@ -15,13 +15,13 @@ You only have two weeks to start collecting candidates, and afterwards supportin
   <label>List owners (two people's names)
     <input id="list_owners" />
   </label><br>
-  <button onclick="candidateTable();supportersTable();" >Generate</button>
+  <button onclick="candidateTable();signaturesTable();" >Generate</button>
 </div>  
 
 <div id="works_council_size"></div>
 
 <table id=candidate_table>
-<caption></caption>
+<caption>Candidates</caption>
   <tr>
     <th scope="col">Rank on list</th>
     <th scope="col">First name</th>
@@ -29,30 +29,18 @@ You only have two weeks to start collecting candidates, and afterwards supportin
     <th scope="col">Date of birth</th>
     <th scope="col">Gender</th>
     <th scope="col">Job title</th>
+    <th scope="col">Signature</th>
   </tr>
-  <tbody id="tableCandidateBody">
-
-  </tbody>
+  <tbody id="candidates_id"></tbody>
 </table>
 
-<table id=supporter_table>
+<table id=supporter_signature_table>
+  <caption>Name of the supporteers themselves</caption>
   <tr>
-    <th scope="col">Rank on list</th>
     <th scope="col">First name</th>
     <th scope="col">Last name</th>
-    <th scope="col">Date of birth</th>
-    <th scope="col">Gender</th>
-    <th scope="col">Job title</th>
+    <th scope="col">Signature</th>
+    <th scope="col">Minimum number of signatures</th>
   </tr>
-  <tr>
-    <th scope="col">Rank on list</th>
-    <th scope="col">First name</th>
-    <th scope="col">Last name</th>
-    <th scope="col">Date of birth</th>
-    <th scope="col">Gender</th>
-    <th scope="col">Job title</th>
-  </tr>
-  <tbody id="tableBody">
-
-  </tbody>
+  <tbody id="signatures_id"></tbody>
 </table>

--- a/works-councils/list-nomination.md
+++ b/works-councils/list-nomination.md
@@ -33,7 +33,7 @@ You only have two weeks to start collecting candidates, and afterwards supportin
   </tr>
   <tbody id="candidates_id"></tbody>
 </table>
-
+<br>
 <table id=supporter_signature_table>
   <caption>Name of the supporteers themselves</caption>
   <tr>

--- a/works-councils/list-nomination.md
+++ b/works-councils/list-nomination.md
@@ -11,9 +11,12 @@ As soon as the Works Council election date is announced, any employee interested
     <input id="employee_count" type="number" min="1" required/>
   </label><br/>
   <label>Name of your list
-    <input id="list_name" />
+    <input id="list_name"/>
   </label><br>
-  <label>List owners (two people's names)
+  <label>If you know <b>exact</b> number of candidates for your list
+    <input id="candidate_count" type="number" min="1"/>
+  </label><br>
+  <label>List owners (two people's names, comma separated)
     <input id="list_owners" />
   </label><br>
   <button onclick="handleTemplateGeneratorFormSubmit()" >Generate</button>
@@ -34,7 +37,7 @@ As soon as the Works Council election date is announced, any employee interested
   <tbody id="candidates_id"></tbody>
 </table>
 <br>
-<table id="supporter_signature_candidate_overview_table">
+<table id="signature_candidate_table">
   <caption>The list of ranked candidates that is presented to co-workers in order for them to decide whether to sign with their supporting signature or not. An employee can only support one list proposal. For small workplaces, signature collection is not necessary.</caption>
   <tr>
     <th scope="col">Rank</th>
@@ -47,7 +50,6 @@ As soon as the Works Council election date is announced, any employee interested
   <tbody id="signatures_candidate_id"></tbody>
 </table>
 <table id="supporter_signature_table">
-  <caption>Name of the supporters themselves</caption>
   <tr>
     <th scope="col">First name</th>
     <th scope="col">Last name</th>
@@ -56,3 +58,10 @@ As soon as the Works Council election date is announced, any employee interested
   </tr>
   <tbody id="signatures_id"></tbody>
 </table>
+
+<script>
+  document.getElementById('employee_count').value = localStorage.getItem('election.employee_count');
+  document.getElementById('candidate_count').value = localStorage.getItem('election.candidate_count');
+  document.getElementById('list_name').value = localStorage.getItem('election.list_name');
+  document.getElementById('list_owners').value = localStorage.getItem('election.list_owners');
+</script>

--- a/works-councils/list-nomination.md
+++ b/works-councils/list-nomination.md
@@ -35,7 +35,7 @@ As soon as the Works Council election date is announced, any employee interested
 </table>
 <br>
 <table id="supporter_signature_candidate_overview_table">
-  <caption>The list of ranked candidates that must be presented to coworkers in order for them to decide whether to sign a supporting signature or not. An employee can only support one list proposal. For small workplaces, signature collective is not necessary.</caption>
+  <caption>The list of ranked candidates that is presented to co-workers in order for them to decide whether to sign with their supporting signature or not. An employee can only support one list proposal. For small workplaces, signature collection is not necessary.</caption>
   <tr>
     <th scope="col">Rank</th>
     <th scope="col">First name</th>

--- a/works-councils/list-nomination.md
+++ b/works-councils/list-nomination.md
@@ -7,36 +7,45 @@ As soon as the Works Council election date is announced, any employee interested
 <br>This website form helps you print a customizeable candidate sheet, that you can use, to start collecting the necessary support to run. After filling out the form, you will receive a printer friendly option to save your customisable sheets. This is not the only way to do it, but it is a model template.
 
 <div class="social-links">
-  <label>Number of employees in your establishment
+  <div class="control">
+    <label for="employee_count">Number of employees in your establishment</label>
     <input id="employee_count" type="number" min="1" required/>
-  </label><br/>
-  <label>Name of your list
+  </div>
+  <div class="control">
+    <label for="list_name">Name of your list</label>
     <input id="list_name"/>
-  </label><br>
-  <label>If you know <b>exact</b> number of candidates for your list
+  </div>
+  <div class="control">
+    <label for="candidate_count">If you know <b>exact</b> number of candidates for your list</label>
     <input id="candidate_count" type="number" min="1"/>
-  </label><br>
-  <label>List owners (two people's names, comma separated)
+  </div>
+  <div class="control">
+    <label for="list_owners">List owners (two people's names, comma separated)</label>
     <input id="list_owners" />
-  </label><br>
-  <button onclick="handleTemplateGeneratorFormSubmit()" >Generate</button>
-</div>  
+  </div>
+  <button class="submit subscribe-button"       onclick="handleTemplateGeneratorFormSubmit()" >Generate
+  </button>
+  <button class="submit subscribe-button" onclick="handleTemplateGeneratorExampleFormSubmit()" >Generate from example
+  </button>
+</div>
 
 <div id="works_council_size"></div>
 
-<table id=candidate_table>
-<caption>List of Candidates</caption>
-  <tr>
-    <th scope="col">First name</th>
-    <th scope="col">Last name</th>
-    <th scope="col">Date of birth</th>
-    <th scope="col">Gender</th>
-    <th scope="col">Job title</th>
-    <th scope="col">Signature</th>
-  </tr>
-  <tbody id="candidates_id"></tbody>
-</table>
-<br>
+## List of candidates
+<div class="page-break">
+  <table id=candidate_table>
+  <caption>List of Candidates</caption>
+    <tr>
+      <th scope="col">First name</th>
+      <th scope="col">Last name</th>
+      <th scope="col">Date of birth</th>
+      <th scope="col">Gender</th>
+      <th scope="col">Job title</th>
+      <th scope="col">Signature</th>
+    </tr>
+    <tbody id="candidates_id"></tbody>
+  </table>
+</div>
 <table id="signature_candidate_table">
   <caption>The list of ranked candidates that is presented to co-workers in order for them to decide whether to sign with their supporting signature or not. An employee can only support one list proposal. For small workplaces, signature collection is not necessary.</caption>
   <tr>
@@ -58,10 +67,3 @@ As soon as the Works Council election date is announced, any employee interested
   </tr>
   <tbody id="signatures_id"></tbody>
 </table>
-
-<script>
-  document.getElementById('employee_count').value = localStorage.getItem('election.employee_count');
-  document.getElementById('candidate_count').value = localStorage.getItem('election.candidate_count');
-  document.getElementById('list_name').value = localStorage.getItem('election.list_name');
-  document.getElementById('list_owners').value = localStorage.getItem('election.list_owners');
-</script>

--- a/works-councils/list-nomination.md
+++ b/works-councils/list-nomination.md
@@ -3,7 +3,8 @@ layout: "page"
 title: "Nominating a list of candidates"
 permalink: /works-councils/nominating-candidates
 ---
-You only have two weeks to start collecting candidates, and afterwards supporting signatures for your list proposal for Works Council elections. This website form helps you print a customizeable candidate sheet, that you can use, to start collecting the necessary support to run. After filling out the form, you will receive a printer friendly option to save your customizeable sheets
+As soon as the Works Council election date is announced, any employee interested in running only has two weeks to prepare list proposal of candidates and afterwards collect supporting signatures.
+<br>This website form helps you print a customizeable candidate sheet, that you can use, to start collecting the necessary support to run. After filling out the form, you will receive a printer friendly option to save your customisable sheets. This is not the only way to do it, but it is a model template.
 
 <div class="social-links">
   <label>Number of employees in your establishment
@@ -21,9 +22,8 @@ You only have two weeks to start collecting candidates, and afterwards supportin
 <div id="works_council_size"></div>
 
 <table id=candidate_table>
-<caption>Candidates</caption>
+<caption>List of Candidates</caption>
   <tr>
-    <th scope="col">Rank on list</th>
     <th scope="col">First name</th>
     <th scope="col">Last name</th>
     <th scope="col">Date of birth</th>
@@ -34,8 +34,20 @@ You only have two weeks to start collecting candidates, and afterwards supportin
   <tbody id="candidates_id"></tbody>
 </table>
 <br>
-<table id=supporter_signature_table>
-  <caption>Name of the supporteers themselves</caption>
+<table id="supporter_signature_candidate_overview_table">
+  <caption>The list of ranked candidates that must be presented to coworkers in order for them to decide whether to sign a supporting signature or not. An employee can only support one list proposal. For small workplaces, signature collective is not necessary.</caption>
+  <tr>
+    <th scope="col">Rank</th>
+    <th scope="col">First name</th>
+    <th scope="col">Last name</th>
+    <th scope="col">Date of birth</th>
+    <th scope="col">Gender</th>
+    <th scope="col">Job title</th>
+  </tr>
+  <tbody id="signatures_candidate_id"></tbody>
+</table>
+<table id="supporter_signature_table">
+  <caption>Name of the supporters themselves</caption>
   <tr>
     <th scope="col">First name</th>
     <th scope="col">Last name</th>

--- a/works-councils/list-nomination.md
+++ b/works-councils/list-nomination.md
@@ -25,7 +25,7 @@ As soon as the Works Council election date is announced, any employee interested
   </div>
   <button class="submit subscribe-button"       onclick="handleTemplateGeneratorFormSubmit()" >Generate
   </button>
-  <button class="submit subscribe-button" onclick="handleTemplateGeneratorExampleFormSubmit()" >Generate from example
+  <button class="submit subscribe-button" onclick="handleTemplateGeneratorExampleFormSubmit()" >Generate random example
   </button>
 </div>
 

--- a/works-councils/list-nomination.md
+++ b/works-councils/list-nomination.md
@@ -16,7 +16,7 @@ As soon as the Works Council election date is announced, any employee interested
   <label>List owners (two people's names)
     <input id="list_owners" />
   </label><br>
-  <button onclick="candidateTable();signaturesTable();" >Generate</button>
+  <button onclick="handleTemplateGeneratorFormSubmit()" >Generate</button>
 </div>  
 
 <div id="works_council_size"></div>

--- a/works-councils/list-nomination.md
+++ b/works-councils/list-nomination.md
@@ -7,7 +7,7 @@ You only have two weeks to start collecting candidates, and afterwards supportin
 
 <div class="social-links">
   <label>Number of employees in your establishment
-    <input id="employee_count" />
+    <input id="employee_count" type="number" min="1" required/>
   </label><br/>
   <label>Name of your list
     <input id="list_name" />

--- a/works-councils/list-nomination.md
+++ b/works-councils/list-nomination.md
@@ -1,0 +1,58 @@
+---
+layout: "page"
+title: "Nominating a list of candidates"
+permalink: /works-councils/nominating-candidates
+---
+You only have two weeks to start collecting candidates, and afterwards supporting signatures for your list proposal for Works Council elections. This website form helps you print a customizeable candidate sheet, that you can use, to start collecting the necessary support to run. After filling out the form, you will receive a printer friendly option to save your customizeable sheets
+
+<div class="social-links">
+  <label>Number of employees in your establishment
+    <input id="employee_count" />
+  </label><br/>
+  <label>Name of your list
+    <input id="list_name" />
+  </label><br>
+  <label>List owners (two people's names)
+    <input id="list_owners" />
+  </label><br>
+  <button onclick="candidateTable();supportersTable();" >Generate</button>
+</div>  
+
+<div id="works_council_size"></div>
+
+<table id=candidate_table>
+<caption></caption>
+  <tr>
+    <th scope="col">Rank on list</th>
+    <th scope="col">First name</th>
+    <th scope="col">Last name</th>
+    <th scope="col">Date of birth</th>
+    <th scope="col">Gender</th>
+    <th scope="col">Job title</th>
+  </tr>
+  <tbody id="tableCandidateBody">
+
+  </tbody>
+</table>
+
+<table id=supporter_table>
+  <tr>
+    <th scope="col">Rank on list</th>
+    <th scope="col">First name</th>
+    <th scope="col">Last name</th>
+    <th scope="col">Date of birth</th>
+    <th scope="col">Gender</th>
+    <th scope="col">Job title</th>
+  </tr>
+  <tr>
+    <th scope="col">Rank on list</th>
+    <th scope="col">First name</th>
+    <th scope="col">Last name</th>
+    <th scope="col">Date of birth</th>
+    <th scope="col">Gender</th>
+    <th scope="col">Job title</th>
+  </tr>
+  <tbody id="tableBody">
+
+  </tbody>
+</table>


### PR DESCRIPTION
Make it easier for prospective works council candidates to create their own list proposal/run. After inputting the size of your workplace, the website tells you how many works council seats there will be, the number of supporting signatures required and the information needed from both candidates and supporters. You can preview the interactive feature here: https://deploy-preview-216--techworkersberlin.netlify.app/works-councils/nominating-candidates

- [x] Make it printer-friendly @acao 
- [x] Improve styling
- [ ] Add more legal descriptions/info
- [x] Add more input fields, such as number of candidates (if it's known/estimated already), gender distribution of workplace,
- [x] Add sample/complete example with fake names/birthdays to give people an idea