### PR TITLE
Fix docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
-jekyll:
-  image: jekyll/jekyll:3.8.5 # Same version as in the Gemfile
-  command: jekyll serve --watch --incremental
-  ports:
-    - 4000:4000
-  volumes:
-    - .:/srv/jekyll
-    - ./vendor/bundle:/usr/local/bundle # Cache gems
+services:
+  jekyll:
+    image: jekyll/jekyll:3.8.5 # Same version as in the Gemfile
+    command: jekyll serve --watch --incremental
+    ports:
+      - 4000:4000
+    volumes:
+      - .:/srv/jekyll
+      - ./vendor/bundle:/usr/local/bundle # Cache gems

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   jekyll:
-    image: jekyll/jekyll:3.8.5 # Same version as in the Gemfile
+    image: jekyll/jekyll:4.2.0 # Same version as in the Gemfile
     command: jekyll serve --watch --incremental
     ports:
       - 4000:4000


### PR DESCRIPTION
Adds `services` top-level element, as per the [docker compose spec](https://docs.docker.com/compose/compose-file/#services-top-level-element).
compose wasn't working without it.