### PR TITLE
Update _layout.scss

### DIFF
--- a/_sass/util/_layout.scss
+++ b/_sass/util/_layout.scss
@@ -21,3 +21,12 @@
     }
   }
 }
+
+[id]::before { 
+  display: block; 
+  content: " "; 
+  margin-top: -73px; // height of nav bar
+  height: 73px; 
+  visibility: hidden; 
+  pointer-events: none;
+}


### PR DESCRIPTION
When using anchor tags, it should adjust for the universal nav bar which is same height on all viewports. This enables jump links to not be blocked by header