### PR TITLE
Decap cms expansion

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -90,3 +90,4 @@ defaults:
       type: "blog"
     values:
       layout: "blog"
+      author: "techworkersber"

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,27 +1,27 @@
-liav_keren:
-  name: Liav Keren
-  picture: /assets/css/images/logo.png
-timo_daum:
-  name: Timo Daum
-  url: http://www.2pir.de/
-  picture: /assets/img/authors/timo_daum.jpg
-igm_berlin:
-  name: IGMetall Berlin
-  twitter: IGMetall_Berlin
-  picture: /assets/img/authors/igm_berlin.jpg
-techworkersber:
-  name: Berlin Tech Workers Coalition
-  twitter: TechWorkersBER
-  picture: /assets/css/images/logo.png
-dziedzic_l:
-  name: Paul L. Dziedzic
-  twitter: dziedzic_l
-  picture: /assets/img/authors/dziedzic_l.jpg
-make_amazon_pay:
-  name: Make Amazon Pay
-  url: www.makeamazonpay.com
-  picture: /assets/img/authors/make_amazon_pay.jpg
-mutova:
-  name: Simon
-  picture: /assets/css/images/logo.png
-title: omg
+entries:
+  - handle: liav_keren
+    name: Liav Keren
+    picture: /assets/css/images/logo.png
+  - handle: timo_daum
+    name: Timo Daum
+    url: http://www.2pir.de/
+    picture: /assets/img/authors/timo_daum.jpg
+  - handle: igm_berlin
+    name: IGMetall Berlin
+    twitter: IGMetall_Berlin
+    picture: /assets/img/authors/igm_berlin.jpg
+  - handle: techworkersber
+    name: Berlin Tech Workers Coalition
+    twitter: TechWorkersBER
+    picture: /assets/css/images/logo.png
+  - handle: dziedzic_l
+    name: Paul L. Dziedzic
+    twitter: dziedzic_l
+    picture: /assets/img/authors/dziedzic_l.jpg
+  - handle: make_amazon_pay
+    name: Make Amazon Pay
+    url: www.makeamazonpay.com
+    picture: /assets/img/authors/make_amazon_pay.jpg
+  - handle: mutova
+    name: Simon
+    picture: /assets/css/images/logo.png

--- a/_data/press.yml
+++ b/_data/press.yml
@@ -1,161 +1,158 @@
-- media: Institute of Network Cultures
-  url: https://networkcultures.org/blog/2023/11/16/tech-workers-global-movement
-  lang: en
-  title: "The State of the Tech Workers Global Movement – Interview with Simone Robutti"
-  byline: "Simone Robutti has been working as a programmer for the last ten years. One day he started to become interested both in the theory of techno politics and the practice of tech worker organization. The interview deals with the organization and action of the Tech Workers Coalition and with the history of tech workers’ resistance."
-  date: 2023-11-16
-
-- media: UNI Global Union
-  url: https://uniglobalunion.org/news/labora23/
-  lang: en
-  title: "Rise in Tech worker unionization: A spotlight at Labor.A conference in Berlin"
-  date: 2023-10-04
-  
-- media: der Freitag
-  url: https://www.freitag.de/autoren/nina-scholz/kuendigungswelle-in-der-start-up-branche-ein-betriebsrat-kann-helfen
-  lang: de
-  title: "Kündigungswelle in der Start-up-Branche: Ein Betriebsrat kann helfen"
-  date: 2023-02-27
-   
-- media: The Left Berlin 
-  url: https://www.theleftberlin.com/we-are-all-resources-being-exploited-by-management-to-make-a-profit-for-the-company/
-  lang: en
-  title: "Socialist Night School Organizing the Warehouse and the Office"
-  byline: "Interview with an organiser and two of the speakers at tomorrow’s DSA Night School on organising in the Warehouse and at the Office"
-  date: 2022-03-30
-  
-- media: MIT Technology Review
-  url: https://www.technologyreview.com/2022/02/07/1044760/tech-workers-unionizing-power/
-  lang: en
-  title: Why the balance of power in tech is shifting toward workers
-  byline: A record number of tech worker unions formed in the US last year. They’re part of a global effort.
-  date: 2022-02-07  
-
-- media: Wired 
-  url: https://www.wired.co.uk/article/gorillas-gig-economy-unions-germany
-  lang: en
-  title: "Europe Went Bananas for Gorillas. Then Its Workers Rose Up"
-  byline: "Every single Amazon fulfillment center that distributes your toys, computers, and clothing is a separately registered entity, and this is exactly what's happening at Gorillas,” says Miller, who believes it could mean Gorillas workers would have to replace a Berlin-wide works council with one for each warehouse. 'It's a very sophisticated way of maneuvering around one large works council and instead creating a fragmented structure.' An Amazon spokesperson confirms each of its buildings in Germany was set up as its own company, but disagrees this is a franchise system"
-  date: 2021-11-30
-
-- media: The Real News Network
-  url: https://www.wired.co.uk/article/gorillas-gig-economy-unions-germany
-  lang: en
-  title: "Berlin's 'new economy' workers fight exploitation and union busting"
-  byline: "Ver.di needs to invest a lot more in social movement organizing and not just a consultative role for the end of a collective bargaining position."
-  date: 2021-11-24
-
-- media: Frankfurter Rundschau
-  url: https://www.fr.de/politik/haertere-strafen-bei-ausbeutung-liav-keren-tech-workers-coalition-90659063.html
-  lang: de
-  title: "Ausbeutung in der Tech-Branche: Liav Keren von der Tech Workers Coalition fordert härtere Strafen"
-  byline: "Eine neue Regierung müsste sich um Abeiterinnen und Arbeiter in der IT-Branche kümmern, findet Liav Keren von der Berlin Tech Workers Coalition"
-  date: 2021-05-25
-
-- media: Frankfurter Rundschau
-  url: https://www.fr.de/wirtschaft/digitalisierung-die-grosse-challenge-in-der-arbeitswelt-90481698.html
-  lang: de
-  title: "Digitalisierung: Die große Herausforderung in der Arbeitswelt"
-  byline: "Youtuber und IT-Beschäftigte organisieren sich gegen die Macht von Google & Co.. Die Gewerkschaften werben um Solo-Selbstständige und kämpfen für mehr Beschäftigtenschutz."
-  date: 2021-05-01
-
-- media: Neues Deutschland
-  url: https://www.neues-deutschland.de/artikel/1150338.tech-workers-coalition-gegen-gehaltsunterschiede-und-raubrittermentalitaet.html
-  lang: de
-  title: "Gegen Gehaltsunterschiede und Raubrittermentalität"
-  byline: "Yonatan Miller weckt mit der Tech Workers Coalition bei Beschäftigten im Hochtechnologiesektor Interesse an politischem Engagement und Betriebsratsarbeit."
-  date: 2021-04-02
- 
-- media: Netzpolitik
-  url: https://netzpolitik.org/2021/interview-zu-tech-gewerkschaften-und-wikipedia-digitale-gewerkschaftsarbeit-ist-noch-ziemlich-neu/
-  lang: de
-  title: Interview zu Tech-Gewerkschaften und Wikipedia
-  byline: Wir sprechen mit Yonatan Miller, Gründer der Tech Workers Coalition Berlin, über den von der Organisation geplanten Edit-a-thon. Er erklärt, warum wir dringend bessere Wikipedia-Artikel zu Gewerkschaften im Technologie-Sektor brauchen.
-  date: 2021-02-11
-
-- media: Netzpolitik
-  url: https://netzpolitik.org/2021/digital-unionism-generally-is-quite-new
-  lang: en
-  title: Interview on tech unions and Wikipedia
-  byline: We sat down with Yonatan Miller, founder of the Tech Workers Coalition Berlin, to speak about the edit-a-thon the organization is planning. He explains why we need better Wikipedia articles on organizing in the technology sector.
-  date: 2021-02-11
-
-- media: Golem
-  url: https://www.golem.de/news/betriebsraete-in-der-tech-branche-freunde-sein-reicht-manchmal-nicht-2012-152169.html
-  lang: de
-  title: Betriebsräte in der Tech-Branche - Freunde sein reicht manchmal nicht
-  byline: Tech-Startups stehen für flache Hierarchien und Spaß am Kickertisch, echte Mitbestimmung wird aber bisweilen unterdrückt. Deshalb gibt es vielerorts wieder den Wunsch nach einem Betriebsrat. 
-  date: 2020-12-07
-
-- media: Sifted
-  url: https://sifted.eu/articles/tesla-gigafactory-berlin/
-  lang: en
-  title: Construction for Tesla's gigafactory in Berlin is full steam ahead, but not everyone is happy about it
-  date: 2020-10-27
-  byline: Germany is steeped in a combustion-based economy
-  twitter: Siftedeu
-
-- media: AK - Anlyse und Kritik
-  url: https://www.akweb.de/bewegung/die-macht-des-shitstorms/
-  lang: de
-  date: 2020-09-15
-  title:  Die Macht des Shitstorms
-  byline: Die Betriebsratswahl bei N26 zeigt neue politische Spielräume im Startup-Sektor auf
-  twitter: analysekritik
-
-- media: KCRW Berlin
-  url: https://kcrwberlin.com/commonground/
-  lang: en
-  date: 2020-09-14
-  title: Should Berlin Become a Tech Hub?
-  twitter: kcrwberlin
-
-- media: Jacobin Magazin
-  lang: de
-  url: https://jacobin.de/artikel/n26-betriebsrat-worker26-start-up/
-  title: "Wie N26 versucht, einen Betriebsrat zu verhindern"
-  date: 2020-08-28
-  twitter: jacobinmag_de
-
-- media: Tagesspegial
-  lang: de
-  url: https://background.tagesspiegel.de/digitalisierung/kaja-santro
-  title: Wirtschaftsziele für die Gleichberechtigung — Porträt Kaja Santro
-  date: 2020-08-04
-  twitter: TspBackgroundDi
-
-- media: Neus Deutschland
-  url: https://www.neues-deutschland.de/artikel/1137662.amazon-in-berlin-amazon-boykottieren-oder-nicht.html
-  lang: de
-  date: 2020-06-09
-  title: Amazon boykottieren oder nicht?
-  twitter: ndaktuell
-
-- media: TAZ
-  lang: de
-  url: https://taz.de/Tech-Worker-ueber-Berlin-vs-Amazon/!5685279/
-  title: Amazon greift nach Grundrechten
-  date: 2020-05-28
-  twitter: tazgezwitscher
-
-- media: AK - Anlyse und Kritik
-  url: https://techworkersberlin.com/blog/2020-05-18-momente-des-aufruhrs/
-  byline: Die Tech-Branche könnte gestärkt aus der Krise hervorgehen – und mit ihr auch eine neue Gegenbewegung von innen
-  lang: de
-  date: 2020-05-18
-  title:  Momente des Aufruhrs
-  twitter: analysekritik
-
-- media: Netzpolitik
-  url: https://netzpolitik.org/2020/widerstand-gegen-silicon-goerli/#vorschaltbanner
-  lang: de
-  date: 2020-01-26
-  title: "Widerstand gegen „Silicon Görli“"
-  twitter: netzpolitik
-
-- media: TAZ
-  lang: de
-  url: https://taz.de/Urbane-Kaempfe-und-Digitalisierung/!5651631/
-  title: "Urbane Kämpfe und Digitalisierung: Der Turmbau zu Berlin"
-  date: 2020-01-14
-  twitter: tazgezwitscher
+entries:
+  - media: der Freitag
+    web_url: https://www.freitag.de/autoren/nina-scholz/kuendigungswelle-in-der-start-up-branche-ein-betriebsrat-kann-helfen
+    lang: de
+    title: "Kündigungswelle in der Start-up-Branche: Ein Betriebsrat kann helfen"
+    date: 2023-02-27
+  - media: The Left Berlin
+    web_url: https://www.theleftberlin.com/we-are-all-resources-being-exploited-by-management-to-make-a-profit-for-the-company/
+    lang: en
+    title: Socialist Night School Organizing the Warehouse and the Office
+    byline: Interview with an organiser and two of the speakers at tomorrow’s DSA
+      Night School on organising in the Warehouse and at the Office
+    date: 2022-03-30
+  - media: MIT Technology Review
+    web_url: https://www.technologyreview.com/2022/02/07/1044760/tech-workers-unionizing-power/
+    lang: en
+    title: Why the balance of power in tech is shifting toward workers
+    byline: A record number of tech worker unions formed in the US last year.
+      They’re part of a global effort.
+    date: 2022-02-07
+  - media: Wired
+    web_url: https://www.wired.co.uk/article/gorillas-gig-economy-unions-germany
+    lang: en
+    title: Europe Went Bananas for Gorillas. Then Its Workers Rose Up
+    byline: Every single Amazon fulfillment center that distributes your toys,
+      computers, and clothing is a separately registered entity, and this is
+      exactly what's happening at Gorillas,” says Miller, who believes it could
+      mean Gorillas workers would have to replace a Berlin-wide works council
+      with one for each warehouse. 'It's a very sophisticated way of maneuvering
+      around one large works council and instead creating a fragmented
+      structure.' An Amazon spokesperson confirms each of its buildings in
+      Germany was set up as its own company, but disagrees this is a franchise
+      system
+    date: 2021-11-30
+  - media: The Real News Network
+    web_url: https://www.wired.co.uk/article/gorillas-gig-economy-unions-germany
+    lang: en
+    title: Berlin's 'new economy' workers fight exploitation and union busting
+    byline: Ver.di needs to invest a lot more in social movement organizing and not
+      just a consultative role for the end of a collective bargaining position.
+    date: 2021-11-24
+  - media: Frankfurter Rundschau
+    web_url: https://www.fr.de/politik/haertere-strafen-bei-ausbeutung-liav-keren-tech-workers-coalition-90659063.html
+    lang: de
+    title: "Ausbeutung in der Tech-Branche: Liav Keren von der Tech Workers
+      Coalition fordert härtere Strafen"
+    byline: Eine neue Regierung müsste sich um Abeiterinnen und Arbeiter in der
+      IT-Branche kümmern, findet Liav Keren von der Berlin Tech Workers
+      Coalition
+    date: 2021-05-25
+  - media: Frankfurter Rundschau
+    web_url: https://www.fr.de/wirtschaft/digitalisierung-die-grosse-challenge-in-der-arbeitswelt-90481698.html
+    lang: de
+    title: "Digitalisierung: Die große Herausforderung in der Arbeitswelt"
+    byline: Youtuber und IT-Beschäftigte organisieren sich gegen die Macht von
+      Google & Co.. Die Gewerkschaften werben um Solo-Selbstständige und kämpfen
+      für mehr Beschäftigtenschutz.
+    date: 2021-05-01
+  - media: Neues Deutschland
+    web_url: https://www.neues-deutschland.de/artikel/1150338.tech-workers-coalition-gegen-gehaltsunterschiede-und-raubrittermentalitaet.html
+    lang: de
+    title: Gegen Gehaltsunterschiede und Raubrittermentalität
+    byline: Yonatan Miller weckt mit der Tech Workers Coalition bei Beschäftigten im
+      Hochtechnologiesektor Interesse an politischem Engagement und
+      Betriebsratsarbeit.
+    date: 2021-04-02
+  - media: Netzpolitik
+    web_url: https://netzpolitik.org/2021/interview-zu-tech-gewerkschaften-und-wikipedia-digitale-gewerkschaftsarbeit-ist-noch-ziemlich-neu/
+    lang: de
+    title: Interview zu Tech-Gewerkschaften und Wikipedia
+    byline: Wir sprechen mit Yonatan Miller, Gründer der Tech Workers Coalition
+      Berlin, über den von der Organisation geplanten Edit-a-thon. Er erklärt,
+      warum wir dringend bessere Wikipedia-Artikel zu Gewerkschaften im
+      Technologie-Sektor brauchen.
+    date: 2021-02-11
+  - media: Netzpolitik
+    web_url: https://netzpolitik.org/2021/digital-unionism-generally-is-quite-new
+    lang: en
+    title: Interview on tech unions and Wikipedia
+    byline: We sat down with Yonatan Miller, founder of the Tech Workers Coalition
+      Berlin, to speak about the edit-a-thon the organization is planning. He
+      explains why we need better Wikipedia articles on organizing in the
+      technology sector.
+    date: 2021-02-11
+  - media: Golem
+    web_url: https://www.golem.de/news/betriebsraete-in-der-tech-branche-freunde-sein-reicht-manchmal-nicht-2012-152169.html
+    lang: de
+    title: Betriebsräte in der Tech-Branche - Freunde sein reicht manchmal nicht
+    byline: Tech-Startups stehen für flache Hierarchien und Spaß am Kickertisch,
+      echte Mitbestimmung wird aber bisweilen unterdrückt. Deshalb gibt es
+      vielerorts wieder den Wunsch nach einem Betriebsrat.
+    date: 2020-12-07
+  - media: Sifted
+    web_url: https://sifted.eu/articles/tesla-gigafactory-berlin/
+    lang: en
+    title: Construction for Tesla's gigafactory in Berlin is full steam ahead, but
+      not everyone is happy about it
+    date: 2020-10-27
+    byline: Germany is steeped in a combustion-based economy
+    twitter: Siftedeu
+  - media: AK - Anlyse und Kritik
+    web_url: https://www.akweb.de/bewegung/die-macht-des-shitstorms/
+    lang: de
+    date: 2020-09-15
+    title: Die Macht des Shitstorms
+    byline: Die Betriebsratswahl bei N26 zeigt neue politische Spielräume im
+      Startup-Sektor auf
+    twitter: analysekritik
+  - media: KCRW Berlin
+    web_url: https://kcrwberlin.com/commonground/
+    lang: en
+    date: 2020-09-14
+    title: Should Berlin Become a Tech Hub?
+    twitter: kcrwberlin
+  - media: Jacobin Magazin
+    lang: de
+    web_url: https://jacobin.de/artikel/n26-betriebsrat-worker26-start-up/
+    title: Wie N26 versucht, einen Betriebsrat zu verhindern
+    date: 2020-08-28
+    twitter: jacobinmag_de
+  - media: Tagesspegial
+    lang: de
+    web_url: https://background.tagesspiegel.de/digitalisierung/kaja-santro
+    title: Wirtschaftsziele für die Gleichberechtigung — Porträt Kaja Santro
+    date: 2020-08-04
+    twitter: TspBackgroundDi
+  - media: Neus Deutschland
+    web_url: https://www.neues-deutschland.de/artikel/1137662.amazon-in-berlin-amazon-boykottieren-oder-nicht.html
+    lang: de
+    date: 2020-06-09
+    title: Amazon boykottieren oder nicht?
+    twitter: ndaktuell
+  - media: TAZ
+    lang: de
+    web_url: https://taz.de/Tech-Worker-ueber-Berlin-vs-Amazon/!5685279/
+    title: Amazon greift nach Grundrechten
+    date: 2020-05-28
+    twitter: tazgezwitscher
+  - media: AK - Anlyse und Kritik
+    web_url: https://techworkersberlin.com/blog/2020-05-18-momente-des-aufruhrs/
+    byline: Die Tech-Branche könnte gestärkt aus der Krise hervorgehen – und mit ihr
+      auch eine neue Gegenbewegung von innen
+    lang: de
+    date: 2020-05-18
+    title: Momente des Aufruhrs
+    twitter: analysekritik
+  - media: Netzpolitik
+    web_url: https://netzpolitik.org/2020/widerstand-gegen-silicon-goerli/#vorschaltbanner
+    lang: de
+    date: 2020-01-26
+    title: Widerstand gegen „Silicon Görli“
+    twitter: netzpolitik
+  - media: TAZ
+    lang: de
+    web_url: https://taz.de/Urbane-Kaempfe-und-Digitalisierung/!5651631/
+    title: "Urbane Kämpfe und Digitalisierung: Der Turmbau zu Berlin"
+    date: 2020-01-14
+    twitter: tazgezwitscher

--- a/_includes/blog.html
+++ b/_includes/blog.html
@@ -8,38 +8,39 @@
   {% assign limit = include.limit %}
   {% assign sorted_posts = site.blog | filter_tags: include.tags | sort: 'date' | reverse %}
   {% for post in sorted_posts limit: limit %}
-    {% assign author = site.data.authors[post.author] | default:
-      site.data.authors['techworkersber'] %}
-
-      <li>
-        <article
-          class="event-card__info-column l-stack -vertical"
-          style="--stack-spacing: 0.5rem"
-          aria-labelledby="news-{{ post.title | slugify }}">
-            <section class="l-stack -horizontal" style="--stack-spacing: 1rem">
-              <div class="l-stack -horizontal" style="--stack-spacing: 0.25rem">
-                {% if author.picture %}
-                  <img
-                    class="h-rounded"
-                    style="--circle-size: 1.75rem"
-                    src="{{author.picture}}"
-                    alt="{{author.name}}"
-                  />
-                {% endif %}
-                <span>{{ author.name }}</span>
-              </div>
-              <time
-                class="aside"
-                datetime="{{ post.date | date: '%Y-%m-%d' }}"
-              >{{ post.date | localize: site.lang, '%-d %B %Y' }}</time>
-            </section>
-            {% if limit %}<h3{% else %}<h2{% endif %}
-              class="event-card__title"
-              id="news-{{ post.title | slugify }}"
-            >
-              <a href="{{ post.url }}" class="event-card__link">{{ post.title }}</a>
-            {% if limit %}</h3>{% else %}</h2>{% endif %}
-        </article>
-      </li>
+    {% for author in site.data.authors.entries %}
+      {% if author.handle == post.author %}
+        <li>
+          <article
+            class="event-card__info-column l-stack -vertical"
+            style="--stack-spacing: 0.5rem"
+            aria-labelledby="news-{{ post.title | slugify }}">
+              <section class="l-stack -horizontal" style="--stack-spacing: 1rem">
+                <div class="l-stack -horizontal" style="--stack-spacing: 0.25rem">
+                  {% if author.picture %}
+                    <img
+                      class="h-rounded"
+                      style="--circle-size: 1.75rem"
+                      src="{{author.picture}}"
+                      alt="{{author.name}}"
+                    />
+                  {% endif %}
+                  <span>{{ author.name }}</span>
+                </div>
+                <time
+                  class="aside"
+                  datetime="{{ post.date | date: '%Y-%m-%d' }}"
+                >{{ post.date | localize: site.lang, '%-d %B %Y' }}</time>
+              </section>
+              {% if limit %}<h3{% else %}<h2{% endif %}
+                class="event-card__title"
+                id="news-{{ post.title | slugify }}"
+              >
+                <a href="{{ post.url }}" class="event-card__link">{{ post.title }}</a>
+              {% if limit %}</h3>{% else %}</h2>{% endif %}
+          </article>
+        </li>
+      {% endif %} 
+    {% endfor %}   
   {% endfor %}
 </ul>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -2,35 +2,37 @@
 layout: default
 ---
 
-<!-- {% assign author = site.data.authors[page.author] %} -->
-<!-- Output author details if some exist. -->
+
 <article class="post">
   <header class="post-header">
     <a href="/blog">{% t 'home.blog.more_articles' %}</a>
     <h1 class="post-title">{{ page.title | escape }}</h1>
-    {% assign author = site.data.authors[page.author] | default: site.data.authors['techworkersber'] %}
-      <section class="l-stack -horizontal -space-large">
-        {% if author.picture %}
-          <img
-            class="h-rounded"
-            style="--circle-size: 4.5rem"
-            src="{{author.picture}}"
-            alt="{{author.name}}"
-          />
-        {% endif %}
-        <div class="l-stack -vertical" style="--stack-spacing: 1rem">
-          <div><b>{{ author.name }}</b></div>
-          <time
-            class="aside"
-            datetime="{{ page.date | date: '%Y-%m-%d' }}"
-            >
-              {{ page.date | localize: site.lang, '%-d %B %Y' }}
-          </time>
-        </div>
-        {% if page.translator %}
-          <span> And translated by {{ page.translator }} </span>
-        {% endif %}
-      </section>
+    {% for author in site.data.authors.entries %}
+      {% if author.handle == page.author %}
+        <section class="l-stack -horizontal -space-large">
+          {% if author.picture %}
+            <img
+              class="h-rounded"
+              style="--circle-size: 4.5rem"
+              src="{{author.picture}}"
+              alt="{{author.name}}"
+            />
+          {% endif %}
+          <div class="l-stack -vertical" style="--stack-spacing: 1rem">
+            <div><b>{{ author.name }}</b></div>
+            <time
+              class="aside"
+              datetime="{{ page.date | date: '%Y-%m-%d' }}"
+              >
+                {{ page.date | localize: site.lang, '%-d %B %Y' }}
+            </time>
+          </div>
+          {% if page.translator %}
+            <span> And translated by {{ page.translator }} </span>
+          {% endif %}
+        </section>
+      {% endif %}    
+    {% endfor %}
   </header>
   <div class="post-content">
     {{ content }}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -33,11 +33,13 @@ collections:
     create: true # Allow users to create new documents in this collection
     fields: # The fields for each document, usually in front matter
       - {label: "Title", name: "title", widget: "string"}
-      - {label: "Press", name: "Press", widget: "relation", collection: "relation_files", file: "press", search_fields: ['press.media'], value_field: "{{press.media}}" }
+      # this is still not working...in worst case...could set it to simple string...but without validation ;p   
+      - {label: "Author", name: "author", widget: "relation", collection: "relation_files", file: "authors", search_fields: ['authors.entries.handle'], value_field: "authors.entries.handle" }
       - {label: "Date", name: "date", widget: "datetime", picker_utc: true }
       - {label: "Canonical url", name: "canonical_url", widget: "string", required: false}
       - {label: "Tags", name: "tags", widget: "list"}
       - {label: "Body", name: "body", widget: "markdown"}
+  
   # Static files inside site/_data
   - label: "Press and authors"
     name: "data"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,3 +1,5 @@
+local_backend: true
+
 backend:
   name: git-gateway
   branch: develop # Branch to update (optional; defaults to master)
@@ -31,8 +33,39 @@ collections:
     create: true # Allow users to create new documents in this collection
     fields: # The fields for each document, usually in front matter
       - {label: "Title", name: "title", widget: "string"}
+      - {label: "Press", name: "Press", widget: "relation", collection: "relation_files", file: "press", search_fields: ['press.media'], value_field: "{{press.media}}" }
       - {label: "Date", name: "date", widget: "datetime", picker_utc: true }
       - {label: "Canonical url", name: "canonical_url", widget: "string", required: false}
       - {label: "Tags", name: "tags", widget: "list"}
       - {label: "Body", name: "body", widget: "markdown"}
-      - {label: "Author", name: "author", widget: "relation", collection: "data.authors", search_fields: ['name'], value_field: "{{name}}" }
+  # Static files inside site/_data
+  - label: "Press and authors"
+    name: "data"
+    files:
+      - label: "Press entries"
+        name: "press"
+        file: "/_data/press.yml"
+        fields:
+          - label: Press entries
+            name: entries
+            widget: list
+            fields:
+              - {label: Publication name, name: media, widget: string}
+              - {label: Link, name: web_url, widget: string}
+              - {label: Language, name: lang, widget: string, default: "en" }
+              - {label: Byline, name: byline, widget: string}
+              - {label: date, name: date, widget: datetime, date_format: "YYYY-MM-DD"}
+              - {label: twitter, name: twitter, widget: string}
+      - label: "Author entries"
+        name: "authors"
+        file: "/_data/authors.yml"
+        fields:
+          - label: Author entries
+            name: entries
+            widget: list
+            fields:
+              - {label: Author handle, name: handle, widget: string}
+              - {label: Human name, name: name, widget: string}
+              - {label: Twitter, name: Twitter, widget: string}
+              - {label: Website, name: url, widget: string}
+              - {label: "Avatar image", name: "picture", widget: "image", required: true}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -3,12 +3,16 @@ backend:
   branch: develop # Branch to update (optional; defaults to master)
   accept_roles: #optional - accepts all users if left out
     - admin
-    - editor
+    - editor  
+  commit_messages:
+    create: Add {{collection}} "{{slug}}" via DecapCMS
+    update: Update {{collection}} "{{slug}}" via DecapCMS
+    delete: Delete {{collection}} "{{slug}}" via DecapCMS
 
 media_folder: "assets/img"
 
 collections:
-  - name: "event" # Used in routes, e.g., /admin/collections/blog
+  - name: "event" # Used in routes, e.g., /admin/collections/event
     label: "Event" # Used in the UI
     folder: "_events" # The path to the folder where the documents are stored
     create: true # Allow users to create new documents in this collection
@@ -20,3 +24,15 @@ collections:
       - {label: "Tags", name: "tags", widget: "list"}
       - {label: "Body", name: "body", widget: "markdown"}
       - {label: "Optional image for SEO", name: "image", widget: "image", required: false}
+  - name: "blog" # Used in routes, e.g., /admin/collections/blog
+    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    label: "Blog" # Used in the UI
+    folder: "_blog" # The path to the folder where the documents are stored
+    create: true # Allow users to create new documents in this collection
+    fields: # The fields for each document, usually in front matter
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Date", name: "date", widget: "datetime", picker_utc: true }
+      - {label: "Canonical url", name: "canonical_url", widget: "string", required: false}
+      - {label: "Tags", name: "tags", widget: "list"}
+      - {label: "Body", name: "body", widget: "markdown"}
+      - {label: "Author", name: "author", widget: "relation", collection: "data.authors", search_fields: ['name'], value_field: "{{name}}" }

--- a/press_mentions.md
+++ b/press_mentions.md
@@ -14,7 +14,7 @@ permalink_de: /pressespiegel
   style="--stack-spacing: 1.5rem"
   role="list">
 
-  {% for post in site.data.press  %}
+  {% for post in site.data.press.entries  %}
     <li>
       <article class="event-card">
         <img


### PR DESCRIPTION
**DecapCMS** provides a User Interface to enable editors to update the website without touching github.com. Behind the hood DecapCMS makes GitHub edits. Before this pull request, only events were editable. Now this includes blog posts, and also the author/press data collections

If you want to add a new press mention inside https://techworkersberlin.com/press, or update an existing blog post inside https://techworkersberlin.com/blog both are now possible via DecapCMS. Addresses issues in #269 


## What's working: 
Adding Authors, Press (data)  and Blog collections are **editable** now!!!
## Not fully working
Selecting the authors/tags inside news or blog posts does not dynamically load/update...so need to know manually what valid author/tags are... 

## Screenshots
<img width="1014" alt="Screenshot 2024-02-04 at 16 18 51" src="https://github.com/techworkersco/twc-site-berlin/assets/7111514/00395f37-198c-436b-841c-f6391a420e0f">
<img width="990" alt="Screenshot 2024-02-04 at 18 26 52" src="https://github.com/techworkersco/twc-site-berlin/assets/7111514/6a225b41-ea4e-4cf3-b621-221223c76764">
