### PR TITLE
Update ordering of events in different views

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -19,7 +19,7 @@ home:
     summary: We as Berlin TWC support the <a href="https://www.dwenteignen.de/wp-content/uploads/2021/03/a5_DWE_INFOFLYER_ENGLISCH.pdf">Deutsche Wohnen & Co enteignen</a> campaign. If you live in Berlin and are eligible to vote, find out how to sign <a href="https://www.dwenteignen.de/unterschreiben/">here</a>.
 
   events:
-    title: Latest events
+    title: Recent events
     more: Find more events
 
   blog:

--- a/_includes/event-card.html
+++ b/_includes/event-card.html
@@ -12,7 +12,7 @@
     xml:space="preserve"
     >
       <path d="M20,3h-1V1h-2v2H7V1H5v2H4C2.9,3,2,3.9,2,5v16c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V5C22,3.9,21.1,3,20,3z M20,21H4V8h16V21z"/>
-      <text transform="matrix(1 0 0 1 5.3281 19.1641)" class="st0 st1">{{ post.date | date: "%d" }}</text>
+      <text transform="matrix(1 0 0 1 5.3281 19.1641)" class="st0 st1">{{ event.date | date: "%d" }}</text>
     </svg>
     <div
     class="event-card__info-column l-stack -vertical"
@@ -20,10 +20,10 @@
     >
     <time
       class="aside event-card__date"
-      datetime="{{ post.date }}"
-    >{{ post.date | localize: site.lang }}</time>
+      datetime="{{ event.date }}"
+    >{{ event.date | localize: site.lang }}</time>
     {% if include.limit %}<h3{% else %}<h2{% endif %} class="event-card__title ">
-      <a href="{{ post.url }}" class="event-card__link">{{ post.title }}</a>
+      <a href="{{ event.url }}" class="event-card__link">{{ event.title }}</a>
     {% if include.limit %}</h3>{% else %}</h2>{% endif %}
     </div>
   </article>

--- a/_includes/event-card.html
+++ b/_includes/event-card.html
@@ -1,0 +1,30 @@
+<li>
+  <article class="event-card">
+    <svg
+    focusable="false"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    x="0px"
+    y="0px"
+    viewBox="0 0 24 24"
+    class="event-card__icon"
+    style="enable-background:new 0 0 24 24;"
+    xml:space="preserve"
+    >
+      <path d="M20,3h-1V1h-2v2H7V1H5v2H4C2.9,3,2,3.9,2,5v16c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V5C22,3.9,21.1,3,20,3z M20,21H4V8h16V21z"/>
+      <text transform="matrix(1 0 0 1 5.3281 19.1641)" class="st0 st1">{{ post.date | date: "%d" }}</text>
+    </svg>
+    <div
+    class="event-card__info-column l-stack -vertical"
+    style="--stack-spacing: 0.25rem"
+    >
+    <time
+      class="aside event-card__date"
+      datetime="{{ post.date }}"
+    >{{ post.date | localize: site.lang }}</time>
+    {% if include.limit %}<h3{% else %}<h2{% endif %} class="event-card__title ">
+      <a href="{{ post.url }}" class="event-card__link">{{ post.title }}</a>
+    {% if include.limit %}</h3>{% else %}</h2>{% endif %}
+    </div>
+  </article>
+</li>  

--- a/_includes/event-card.html
+++ b/_includes/event-card.html
@@ -22,9 +22,15 @@
       class="aside event-card__date"
       datetime="{{ event.date }}"
     >{{ event.date | localize: site.lang }}</time>
-    {% if include.limit %}<h3{% else %}<h2{% endif %} class="event-card__title ">
-      <a href="{{ event.url }}" class="event-card__link">{{ event.title }}</a>
-    {% if include.limit %}</h3>{% else %}</h2>{% endif %}
+    {% if include.limit %}
+      <h3 class="event-card__title">
+        <a href="{{ event.url }}" class="event-card__link">{{ event.title }}</a>
+      </h3>
+    {% else %}
+      <h2 class="event-card__title">
+        <a href="{{ event.url }}" class="event-card__link">{{ event.title }}</a>
+      </h2>
+    {% endif %}
     </div>
   </article>
 </li>  

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -6,13 +6,15 @@
   style="--stack-spacing: 1.5rem"
   role="list"
 >
-  {% assign sorted_posts = site.events | filter_tags: include.tags | reverse %}
-  {% if include.limit %}  
-    {% for post in sorted_posts reversed limit: include.limit %}  
-      {% include event-card.html limit=include.limit %}
-    {% endfor %}
-  {% else %} 
-    {% for post in sorted_posts %}  
+  {% assign events = site.events | filter_tags: include.tags | reverse %}
+  {% assign future_events = events | where_exp: "event", "event.date >= site.time" %}   
+  
+  {% if include.limit and future_events.size > 0 %}
+    {% for event in future_events reversed limit: include.limit  %}  
+      {% include event-card.html %}
+    {% endfor %} 
+  {% else %}  
+    {% for event in events limit: include.limit  %}
       {% include event-card.html %}
     {% endfor %}
   {% endif %}  

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -6,38 +6,14 @@
   style="--stack-spacing: 1.5rem"
   role="list"
 >
-  {% assign limit = include.limit %}
-  {% assign sorted_posts = site.events | sort: 'date' | filter_tags: include.tags | reverse %}
-  {% for post in sorted_posts limit: limit %}
-    <li>
-      <article class="event-card">
-        <svg
-          focusable="false"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-          x="0px"
-          y="0px"
-          viewBox="0 0 24 24"
-          class="event-card__icon"
-          style="enable-background:new 0 0 24 24;"
-          xml:space="preserve"
-        >
-          <path d="M20,3h-1V1h-2v2H7V1H5v2H4C2.9,3,2,3.9,2,5v16c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V5C22,3.9,21.1,3,20,3z M20,21H4V8h16V21z"/>
-          <text transform="matrix(1 0 0 1 5.3281 19.1641)" class="st0 st1">{{ post.date | date: "%d" }}</text>
-        </svg>
-        <div
-          class="event-card__info-column l-stack -vertical"
-          style="--stack-spacing: 0.25rem"
-        >
-          <time
-            class="aside event-card__date"
-            datetime="{{ post.date }}"
-          >{{ post.date | localize: site.lang }}</time>
-          {% if limit %}<h3{% else %}<h2{% endif %} class="event-card__title ">
-            <a href="{{ post.url }}" class="event-card__link">{{ post.title }}</a>
-          {% if limit %}</h3>{% else %}</h2>{% endif %}
-        </div>
-      </article>
-    </li>
-  {% endfor %}
+  {% assign sorted_posts = site.events | filter_tags: include.tags | reverse %}
+  {% if include.limit %}  
+    {% for post in sorted_posts reversed limit: include.limit %}  
+      {% include event-card.html limit=include.limit %}
+    {% endfor %}
+  {% else %} 
+    {% for post in sorted_posts %}  
+      {% include event-card.html %}
+    {% endfor %}
+  {% endif %}  
 </ul>

--- a/works-councils/works-councils.md
+++ b/works-councils/works-councils.md
@@ -19,7 +19,7 @@ We support the formation of Works Councils (Betriebsräte) as a means to organiz
 
 We host Works Council trainings regularly. We provide a forum and safe space to share experiences and learn from each other.
 
-{% include events.html tags="works-council" limit=5 %}
+{% include events.html tags="works-council" limit=3 %}
 
 ## Blog
 


### PR DESCRIPTION
If there is no limit specified, show the latest events on top; if there is a limit filter (e.g limit: 5) query the latest events, limit them and then again reverse the order, for easier chronological reading.

Currently on the home page, as well as [/learning](https://techworkersberlin.com/learning) and [/works-councils](https://techworkersberlin.com/works-councils) the latest event was shown on top, even though it might be more intuitive to show the oldest events first (when there's a small number). 

- [x] Update order on events with a filter limit i.e [/learning](https://techworkersberlin.com/learning) and [/works-councils](https://techworkersberlin.com/works-councils)
- [x] Leave [/events ](techworkersberlin.com/events) unchanged

# The changes
## Before this PR on home page (7 May on top)
<img width="561" alt="Screenshot 2024-02-16 at 04 32 09" src="https://github.com/techworkersco/twc-site-berlin/assets/7111514/1636c2bc-e149-43bf-b4ba-5f8accde09b6">

## After this PR on home page (7 May on bottom)
<img width="545" alt="Screenshot 2024-02-16 at 04 29 47" src="https://github.com/techworkersco/twc-site-berlin/assets/7111514/a0a2d590-f5d8-4179-af92-880007d5b847">

## The [/events ](techworkersberlin.com/events) remains exactly the same as before
<img width="682" alt="Screenshot 2024-02-16 at 04 22 23" src="https://github.com/techworkersco/twc-site-berlin/assets/7111514/8be6d34f-2ab7-4e43-a3b7-08271ea048d0">
