### PR TITLE
Add json feed of events

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     method_source (1.0.0)
+    nokogiri (1.16.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.2-x64-mingw-ucrt)
       racc (~> 1.4)
     pathutil (0.16.2)
@@ -109,6 +111,8 @@ GEM
     rouge (4.2.0)
     ruby-rc4 (0.1.5)
     safe_yaml (1.0.5)
+    sass-embedded (1.69.7-arm64-darwin)
+      google-protobuf (~> 3.25)
     sass-embedded (1.69.7-x64-mingw-ucrt)
       google-protobuf (~> 3.25)
     terminal-table (3.0.2)
@@ -127,6 +131,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-23
   x64-mingw-ucrt
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Note, only the default [en.yml](_i18n/en.yml) must contain the names of each lan
 
 ![Screen Shot 2019-07-21 at 14 48 46](https://user-images.githubusercontent.com/7111514/61591397-cb0cd180-abc6-11e9-9876-1577d5c8b4bd.png)
 
+
+### API feeds
+
+Currently [techworkerscoalition.org](https://techworkerscoalition.org) uses Berlin press and events either from GitHub or directly from our exposed APIs e.g [/events.json](https://techworkersberlin.com/events.json). You can find other uses cases [here](https://github.com/techworkersco/twc-site/blob/master/_config.yml#L32)
+
+
 ### Supported Pages
 * Landing Page [index.yml](index.md)
 * Join Page [join.md](join.md)

--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,8 @@
 title: Berlin Tech Workers Coalition
 email: contact@techworkerberlin.com
 description: Berlin Tech Workers Coalition is a landing page for tech workers looking to organise their workplace. Whether it is through Works Councils (Betriebsräte), union campaigns for higher wages, or broader struggles against racism and gentrification, we are here to support you! Tech Won’t Save Us...Organise! ✊ We are the largest English speaking network of Works Councils, tech workers and trade union members supporting each other in different tech companies like Soundcloud, Contentful, ShareNow, Amazon, SumUp, N26, TikTok and maybe your company!
-url: "https://techworkersberlin.com" # the subpath of your site, e.g. /blog
-baseurl: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://techworkersberlin.com" 
+baseurl: "" 
 timezone: "Europe/Berlin"
 
 sass:

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -15,6 +15,7 @@ collections:
     fields: # The fields for each document, usually in front matter
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Date", name: "date", widget: "datetime"}
+      - {label: "Locations", name: "locations", widget: "select", multiple: true, default: ["Global", min: 1, options: ["Global", "Online", "Berlin"]]}
       - {label: "hide signup form", name: "hide_form", widget: "boolean", default: false}
       - {label: "Canonical url", name: "canonical_url", widget: "string", required: false}
       - {label: "Tags", name: "tags", widget: "list"}

--- a/events.json
+++ b/events.json
@@ -1,0 +1,12 @@
+---
+layout: null
+---
+[{% for event in site.events %}
+{"date":{{ event.date | date: "%s"}},
+"chapter":"Berlin",
+"title":"{{ event.title}}",
+"tags":{{event.tags | jsonify}},
+"timeszones":["Europe/Berlin"],
+"image":"{{ site.url }}{{event.image}}",
+"url":"{{ site.url }}{{event.url}}"}{% unless forloop.last %},{% endunless %}
+{% endfor %}]

--- a/events.yml
+++ b/events.yml
@@ -4,7 +4,7 @@ layout: null
 {% for event in site.events %}
 - title: "{{event.title}}"
   date: {{event.date}}
-  chapter: Berlin
+  locations: [Berlin]
   tags: {{event.tags}} 
   timeszones: [Europe/Berlin]
   image: {{site.url}}{{event.image}}

--- a/events.yml
+++ b/events.yml
@@ -1,0 +1,12 @@
+---
+layout: null
+---
+{% for event in site.events %}
+- title: "{{event.title}}"
+  date: {{event.date}}
+  chapter: Berlin
+  tags: {{event.tags}} 
+  timeszones: [Europe/Berlin]
+  image: {{site.url}}{{event.image}}
+  url: {{site.url}}{{event.url}}
+{% endfor %}


### PR DESCRIPTION
- techworkersberlin.com/events.json will make it possible to consume events as json, for whatever clients. Specifically will allow Berlin events to be displayed within the global TWC website 

- validated json schema using https://jsonlint.com/