### PR TITLE
Fix absolute image URLs in events list

### DIFF
--- a/events.json
+++ b/events.json
@@ -7,6 +7,6 @@ layout: null
 "title":"{{ event.title}}",
 "tags":{{event.tags | jsonify}},
 "timeszones":["Europe/Berlin"],
-"image":"{{ site.url }}{{event.image}}",
+"image":"{{ event.image | absolute_url }}",
 "url":"{{ site.url }}{{event.url}}"}{% unless forloop.last %},{% endunless %}
 {% endfor %}]

--- a/events.yml
+++ b/events.yml
@@ -7,6 +7,6 @@ layout: null
   locations: [Berlin]
   tags: {{event.tags}} 
   timeszones: [Europe/Berlin]
-  image: {{site.url}}{{event.image}}
+  image: {{ event.image | absolute_url }}
   url: {{site.url}}{{event.url}}
 {% endfor %}


### PR DESCRIPTION
`events.yml` and `events.json` were doing a simple concatenation of `site.url` and `event.image`, which worked for relative URLs but broke absolute URLs. For example,
`https://info.rosalux.de/image/event/3bod2?type=2` became `https://techworkersberlin.com/https://info.rosalux.de/image/event/3bod2?type=2`, which is wrong.

This causes issues for anyone consuming this data, such as [this bug on techworkerscoalition.org][0].

This fixes that with [Jekyll's built-in `absolute_url` filter][1], which [doesn't change URLs that are already absolute][2].

[0]: https://github.com/techworkersco/twc-site/issues/431
[1]: https://jekyllrb.com/docs/liquid/filters/#absolute-url
[2]: https://github.com/jekyll/jekyll/blob/76982c73c0df37ac79781ec1ef9518e08263a158/lib/jekyll/filters/url_filters.rb#L62